### PR TITLE
Always On: reconnect on boot and after interruptions

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -161,6 +161,41 @@ function parseActiveVpn(raw) {
   return { active: false, name: "", server: "", device: "", type: "" }
 }
 
+// `protonvpn connect` prints "Connected to NL#42 in Amsterdam, Netherlands."
+// on success, but not always first: with an expired server list the CLI
+// prints "Server list is outdated, updating..." ahead of it. So the line is
+// searched for, never assumed to be line 0. Returns "" when there isn't one.
+function connectedLine(raw) {
+  var lines = stripAnsi(raw).split("\n")
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i].trim()
+    if (/^connected to\s+\S/i.test(line)) return line
+  }
+  return ""
+}
+
+// That line is the only place a Fastest/Random/P2P connect names the server it
+// actually landed on, so it's what lets those show up in Recent alongside
+// cities picked by hand.
+function parseConnected(raw) {
+  var line = connectedLine(raw)
+  if (line === "") return null
+  var m = line.match(/connected to\s+(.+?)\s*\.?\s*$/i)
+  if (!m) return null
+  var rest = m[1]
+  var name = serverName(rest)
+  if (name === "") return null
+  var location = serverLocation(rest)
+  var city = location
+  var country = ""
+  var comma = location.lastIndexOf(",")
+  if (comma > 0) {
+    city = location.substring(0, comma).trim()
+    country = location.substring(comma + 1).trim()
+  }
+  return { name: name, city: city, country: country }
+}
+
 function filterCountries(countries, query) {
   var q = String(query || "").trim().toLowerCase()
   if (q === "") return countries

--- a/Panel.qml
+++ b/Panel.qml
@@ -97,7 +97,7 @@ Panel {
     list.push({ name: "quick", count: quickActions.length })
     list.push({ name: "tabs", count: tabs.length })
     if (tab === "protection") {
-      list.push({ name: "protection", count: 3 })
+      list.push({ name: "protection", count: 4 })
     } else {
       if (vpn.recents.length > 0) list.push({ name: "recents", count: vpn.recents.length })
       if (drilled) list.push({ name: "servers", count: serverRowCount })
@@ -246,6 +246,7 @@ Panel {
     else if (focusSection === "protection") {
       if (protectionIndex === 0) vpn.toggleKillSwitch()
       else if (protectionIndex === 1) vpn.toggleNetShield()
+      else if (protectionIndex === 2) vpn.toggleAutoConnect()
       else requestSignOut()
     }
     else if (focusSection === "recents") { vpn.connectRecent(recentIndex); showConnection() }
@@ -343,9 +344,9 @@ Panel {
     else if (focusSection === "countries") column = countryColumn
     else if (focusSection === "servers") column = serverColumn
     var i = sectionIndex(focusSection)
-    // The Protection column carries the Account header and rows after its two
-    // switches; the sign-out row is its last child.
-    if (focusSection === "protection" && i === 2 && column) i = column.children.length - 1
+    // The Protection column carries the Account header and rows after its
+    // three switches; the sign-out row is its last child.
+    if (focusSection === "protection" && i === 3 && column) i = column.children.length - 1
     if (column && i >= 0 && i < column.children.length) scrollItemIntoView(column.children[i])
   }
 
@@ -430,6 +431,7 @@ Panel {
         connected: vpn.connected,
         busy: vpn.busy,
         killSwitch: vpn.config["kill-switch"] || "",
+        configPending: vpn.configPending,
         netshield: vpn.config["netshield"] || "",
         countries: vpn.countries.length,
         recents: vpn.recents.length,
@@ -438,6 +440,13 @@ Panel {
         currentPlace: vpn.currentPlace ? vpn.currentPlace.city + ", " + vpn.currentPlace.code : "",
         stateLoaded: vpn.stateLoaded,
         nudgeDismissed: vpn.nudgeDismissed,
+        autoConnect: vpn.autoConnect,
+        autoReady: vpn.autoReady,
+        linkActive: vpn.linkActive,
+        statusConnected: vpn.statusConnected,
+        desired: vpn._desired,
+        autoWaitMs: Math.max(0, vpn._autoNextMs - Date.now()),
+        pinFailed: vpn._autoPinFailed,
         drilledInto: vpn.serversCountry,
         servers: vpn.servers.length,
         lastError: vpn.lastError
@@ -755,11 +764,13 @@ Panel {
                 spacing: Style.space(8)
 
                 Button {
-                  text: vpn.configBusy ? "Turning on…" : "Turn on"
+                  // Held through the re-read too, so the button stops saying
+                  // "Turning on…" at the same moment the switch flips.
+                  text: vpn.configPending === "kill-switch" ? "Turning on…" : "Turn on"
                   bordered: true
                   foreground: root.foreground
                   hasCursor: root.cursorActive && root.focusSection === "nudge" && root.nudgeIndex === 0
-                  enabled: !vpn.configBusy
+                  enabled: vpn.configPending === ""
                   onClicked: vpn.toggleKillSwitch()
                 }
 
@@ -854,9 +865,10 @@ Panel {
               Toggle {
                 width: parent.width
                 label: "Kill Switch"
-                description: vpn.configLoaded ? "Block internet if the VPN drops" : "Loading…"
+                description: vpn.configPendingLabel("kill-switch")
+                  || (vpn.configLoaded ? "Block internet if the VPN drops" : "Loading…")
                 checked: vpn.killSwitchOn
-                enabled: vpn.configLoaded && !vpn.configBusy
+                enabled: vpn.configLoaded && vpn.configPending === ""
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 0
                 foreground: root.foreground
                 fontFamily: root.fontFamily
@@ -868,6 +880,8 @@ Panel {
                 width: parent.width
                 label: "NetShield"
                 description: {
+                  var applying = vpn.configPendingLabel("netshield")
+                  if (applying !== "") return applying
                   if (!vpn.configLoaded) return "Loading…"
                   var v = String(vpn.config["netshield"] || "off")
                   if (v === "malware-ads-trackers") return "Blocking malware, ads and trackers"
@@ -875,12 +889,27 @@ Panel {
                   return "Block malware, ads and trackers"
                 }
                 checked: vpn.netShieldOn
-                enabled: vpn.configLoaded && !vpn.configBusy
+                enabled: vpn.configLoaded && vpn.configPending === ""
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 1
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursor("protection", 1) }
                 onClicked: { root.clearHighlight(); vpn.toggleNetShield() }
+              }
+
+              // Widget-owned, unlike the two above: the CLI has no setting for
+              // this, so it lives in the widget's own state file.
+              Toggle {
+                width: parent.width
+                label: "Always On"
+                description: "Reconnects on boot and interruptions"
+                checked: vpn.autoConnect
+                enabled: !vpn.busy
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursor("protection", 2) }
+                onClicked: { root.clearHighlight(); vpn.toggleAutoConnect() }
               }
 
               // ── Account ─────────────────────────────────────────────────
@@ -900,12 +929,12 @@ Panel {
 
               ActionRow {
                 width: parent.width
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
                 icon: "󰍃"
                 title: root.signOutArmed ? "Click again to sign out" : "Sign out"
                 subtitle: root.signOutArmed ? "Disconnects and clears the session on this computer" : "You'll need your password and 2FA to sign back in"
                 enabled: !vpn.busy
-                onEntered: root.setCursor("protection", 2)
+                onEntered: root.setCursor("protection", 3)
                 onClicked: root.requestSignOut()
               }
             }

--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ Under Quick Connect sit two tabs, in the same pill style as Omarchy's network
 panel. **Connections** holds everywhere you can go, recent places, the
 country and city lists, and saved profiles when they land. **Protection**
 holds everything about *how* you're protected, the Kill Switch, NetShield,
-and the settings still to come (split tunneling, auto-connect). The tab you
+Always On, and the settings still to come (split tunneling). The tab you
 pick stays until you close the panel.
 
 ### Protection
 
 <img src="docs/protection.png" width="360" alt="The Protection tab: Kill Switch and NetShield switches, account, and sign out">
 
-Two switches, saved to Proton's own settings:
+Two switches saved to Proton's own settings:
 
 - **Kill Switch**: if the VPN drops, your internet is blocked until it's back.
   Without this, a dropped tunnel silently falls back to your plain connection
@@ -202,6 +202,28 @@ Two switches, saved to Proton's own settings:
 - **NetShield**: blocks malware, ads, and trackers at the DNS level. On a free
   plan Proton only allows malware blocking; the widget steps down to that
   automatically.
+
+And one saved by the widget itself, because the CLI has no setting for it:
+
+- **Always On**: whenever Proton isn't connected, connect it. That covers
+  booting, logging in, joining a café Wi-Fi, and a tunnel that drops on its own,
+  they're all just moments when you aren't protected and should be. It's
+  checked on the same few-second poll that drives the bar icon, so there's
+  nothing extra running. **Off by default.**
+
+  It reconnects to the top of your **Recent** list, which is the server you
+  were last actually on. If that server is full or gone, the attempt fails
+  once and the next one falls back to Fastest, so it can't get stuck retrying
+  a server that isn't coming back. With nothing in Recent yet it just uses
+  Fastest. Never a Plus-only target, so a free account isn't sent somewhere
+  it can't go. A connect that fails waits 30 seconds before trying again, so
+  a dead network, or a café portal you haven't signed into yet, doesn't get
+  hammered.
+
+  Two things worth knowing. It never fires while you're signed out, and it
+  will never open a sign-in terminal on its own. And while it's on, the
+  **Disconnect** button won't keep you disconnected, you'll be reconnected
+  within a few seconds; switch Always On off if you want to stay off.
 
 Below the switches, **Account** shows who's signed in and the plan, with a
 **Sign out** row, it asks for a second click within five seconds, because
@@ -215,6 +237,12 @@ in the widget's settings if you'd rather not.
 
 The last three places you connected to, pinned above the country list. Most
 people use the same two or three locations forever; this makes them one click.
+
+Every successful connection lands here, including **Fastest**, **Random**,
+**P2P**, **Secure Core** and **Tor**. Those don't name a destination when you
+click them, but they still put you somewhere, so the server they picked is
+recorded by name and city, and clicking it again takes you straight back.
+That top entry is also what Always On reconnects to.
 
 ### Connections → Countries and cities
 
@@ -315,8 +343,8 @@ Omarchy plugin. It:
   connected-city lookup all come from it), reads the tunnel's byte counters
   under `/sys/class/net/` once a second while the panel is open, and writes
   exactly one file of its own
-  (`~/.local/state/omarchy-protonvpn/state.json`: recent location labels and
-  whether you dismissed the Kill Switch prompt)
+  (`~/.local/state/omarchy-protonvpn/state.json`: recent location labels,
+  whether you dismissed the Kill Switch prompt, and whether Always On is on)
 
 **Sign-in.** Your password and 2FA code go straight to the `protonvpn` CLI's
 own prompt in a terminal; this plugin never sees them. The username you type in
@@ -335,7 +363,9 @@ no other key or value can reach the CLI from this code.
 Quickshell IPC socket under `/run/user/<uid>/`, which only your own user (and
 root) can reach. Through it, any process running as you can call this widget's
 `connect`, `disconnect`, `status`, and `debug` methods, the same things that
-process could already do by running `protonvpn` directly. `status` returns the
+process could already do by running `protonvpn` directly. Note that while
+Always On is enabled, an IPC `disconnect` is undone within a few seconds, same
+as the button. `status` returns the
 server name; `debug` deliberately omits your account email. The email is shown
 only inside the panel.
 

--- a/Service.qml
+++ b/Service.qml
@@ -102,6 +102,30 @@ Item {
   property var recents: []
   property bool nudgeDismissed: false
   property bool stateLoaded: false
+
+  // ── Always On ───────────────────────────────────────────────────────────
+  // One invariant, not a set of triggers: if the switch is on and the tunnel
+  // isn't up, bring it up. Signing in, joining a network and a dropped tunnel
+  // are all just moments when that stops being true, so the nmcli poll that
+  // already runs for the bar icon is the whole mechanism. No second watcher,
+  // no second process, nothing to keep in sync.
+  //
+  // The CLI has no always-on mode of its own, and NetworkManager can't own it
+  // either: the CLI re-creates its WireGuard profile on every connect, so an
+  // NM autoconnect flag would only fight it.
+  property bool autoConnect: false
+  // Set when an automatic connect fails, so the next attempt falls back to
+  // Fastest instead of retrying a server that is full or gone, forever.
+  property bool _autoPinFailed: false
+  // Don't retry a failed connect on the very next poll: `protonvpn connect`
+  // against a dead network fails slowly and there is no point hammering it.
+  readonly property int autoRetryMs: 30000
+  property real _autoNextMs: 0
+  // True while the in-flight connect was started by the reconciler rather
+  // than a click, so only its failures arm the retry delay.
+  property bool _autoAttempt: false
+
+  readonly property bool autoReady: installed && signedIn && accountProbed && stateLoaded && autoConnect
   readonly property string stateDir: (Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")) + "/omarchy-protonvpn"
   readonly property string statePath: stateDir + "/state.json"
 
@@ -118,13 +142,59 @@ Item {
   property bool _expectDown: false
   // What the in-flight connect was asked for, recorded to recents on success.
   property var _target: null
+  // When the last action finished, and when the in-flight link poll started.
+  // A poll that began before the action ended carries pre-action data, so it
+  // must not be used to decide whether the action took effect.
+  property real _actionEndedMs: 0
+  property real _watchStartedMs: 0
   property string _configKey: ""
   property string _configValue: ""
 
   readonly property bool connected: _desired === -1 ? (linkActive || statusConnected) : (_desired === 1)
   readonly property bool busy: actionProcess.running || connectProcess.running
+
+  // Every `protonvpn` call is a fresh Python process that loads, and may
+  // rewrite, Proton's shared 24MB server cache. The CLI takes no lock on it:
+  // two processes refreshing at once can race and leave every server in that
+  // file marked down, at which point the CLI refuses to pick a server at all
+  // ("No servers found matching criteria") until the list is refetched, which
+  // it will not do while its own copy looks fresh.
+  //
+  // So the read-only probes take turns, and stand aside while an action the
+  // person asked for is running. Actions are already serialized by `busy`.
+  // This also cuts a connect from ~9-15 CLI processes down to one.
+  // Deliberately a plain flag, not a binding over the Process objects. A
+  // binding does not re-evaluate between two statements of the same function,
+  // so refresh()'s `refreshStatus(); refreshAccount();` would both read "not
+  // busy" and start together: exactly the pair that raced and corrupted the
+  // cache. This is set the instant a probe launches and cleared when it exits.
+  property bool _probeRunning: false
+  readonly property bool cliBusy: _probeRunning || busy
+  // One flag per probe that stepped aside, so each is retried rather than
+  // lost. Deliberately not a single shared flag: the two frequent probes
+  // (status, info) always have work to do, so a shared flag lets them take
+  // the slot forever and starve the country and config loads.
+  property bool _wantStatus: false
+  property bool _wantAccount: false
+  property bool _wantCountries: false
+  property bool _wantConfig: false
+  readonly property bool _probesPending: _wantStatus || _wantAccount || _wantCountries || _wantConfig
   readonly property bool refreshing: statusProcess.running
-  readonly property bool configBusy: setConfigProcess.running
+  // Which config key is mid-change, "" when nothing is, and the value it's
+  // heading for. A click costs two CLI runs, `config set` then the `config
+  // list` re-read that confirms it, about 1.4s of CLI startup between them,
+  // and the switch can't move until the second lands. Rather than throw the
+  // knob early and hope, the row keeps showing the value the CLI last
+  // reported and says what it's doing, the same way displayStatus says
+  // "Connecting…". Cleared by the re-read, so it covers both runs.
+  property string configPending: ""
+  property string configPendingValue: ""
+
+  // "" unless that row is the one mid-change.
+  function configPendingLabel(key) {
+    if (configPending !== key) return ""
+    return configPendingValue === "off" ? "Turning off…" : "Turning on…"
+  }
 
   readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 30, 5, 3600)
   readonly property int watchIntervalSec: intSetting("watchIntervalSec", 4, 2, 60)
@@ -164,8 +234,11 @@ Item {
       return
     }
     watchLink()
-    refreshStatus()
+    // Account first: `signedIn` gates the map, the tabs and every setting, so
+    // probing it before the detail rows is what stops the panel looking empty
+    // for the first few seconds after a shell restart.
     refreshAccount()
+    refreshStatus()
   }
 
   function probeInstalled() {
@@ -191,42 +264,66 @@ Item {
 
   function watchLink() {
     if (watchProcess.running) return
+    _watchStartedMs = Date.now()
     watchProcess.command = ["nmcli", "-t", "-f", "NAME,TYPE,DEVICE,STATE", "connection", "show", "--active"]
     watchProcess.running = true
   }
 
   function refreshStatus() {
-    if (!installed || statusProcess.running) return
+    if (!installed) return
+    if (cliBusy) { _wantStatus = true; return }
+    _probeRunning = true
     statusProcess.command = ["protonvpn", "status"]
     statusProcess.running = true
   }
 
   function refreshAccount() {
-    if (!installed || accountProcess.running) return
+    if (!installed) return
+    if (cliBusy) { _wantAccount = true; return }
+    _probeRunning = true
     accountProcess.command = ["protonvpn", "info"]
     accountProcess.running = true
   }
 
   function loadCountries(force) {
-    if (!installed || !signedIn || countriesProcess.running) return
+    if (!installed || !signedIn) return
     if (countriesLoaded && force !== true) return
+    if (cliBusy) { _wantCountries = true; return }
+    _probeRunning = true
     countriesProcess.command = ["protonvpn", "countries", "list"]
     countriesProcess.running = true
   }
 
   function loadConfig() {
-    if (!installed || !signedIn || configProcess.running) return
+    // Nothing left to wait for, and no re-read coming to clear it.
+    if (!installed || !signedIn) { configPending = ""; configPendingValue = ""; return }
+    if (cliBusy) { _wantConfig = true; return }
+    _probeRunning = true
     configProcess.command = ["protonvpn", "config", "list"]
     configProcess.running = true
   }
 
   // Both key and value must be in configValues; anything else is dropped.
+  //
+  // Refuses while a change is still settling, so a second click (or an Enter
+  // from the keyboard cursor, which doesn't go through the row's `enabled`)
+  // can't send a contradicting `config set` at a value the panel hasn't been
+  // told about yet.
   function setConfig(key, value) {
+    if (configPending !== "" || setConfigProcess.running) return
+    applyConfig(key, value)
+  }
+
+  // The set itself, without the in-flight guard, so the NetShield step-down
+  // below can hand off from one failed attempt straight into the next.
+  function applyConfig(key, value) {
     var allowed = configValues[key]
     if (!allowed || allowed.indexOf(value) === -1) return
-    if (!installed || !signedIn || setConfigProcess.running) return
+    if (!installed || !signedIn) return
     _configKey = key
     _configValue = value
+    configPending = key
+    configPendingValue = value
     lastError = ""
     setConfigProcess.command = ["protonvpn", "config", "set", key, value]
     setConfigProcess.running = true
@@ -258,8 +355,9 @@ Item {
 
   // target: {key, title, subtitle, args} recorded to recents on success, or
   // null for quick actions that are already one click away.
-  function connectTo(args, label, target) {
+  function connectTo(args, label, target, auto) {
     if (!installed || !signedIn || busy) return
+    _autoAttempt = auto === true
     _desired = 1
     _expectDown = false
     _target = target
@@ -440,30 +538,90 @@ Item {
     reconcile()
   }
 
+  // Drop the optimistic override as soon as the world agrees with it, and
+  // also once the action that set it has finished, whatever the outcome.
+  //
+  // That second condition is not belt-and-braces. The override says "ignore
+  // reality, this is where we're heading", and it used to be released only on
+  // agreement. Always On can bring the tunnel straight back up as a
+  // disconnect completes, so reality settles on the opposite of what was
+  // asked, the two never agree, and the override latches for the rest of the
+  // session: the panel reads "Not protected" over a live tunnel and the power
+  // button starts connecting instead of disconnecting.
+  //
+  // Both callers run this against freshly polled state (nmcli in the link
+  // watcher, `protonvpn status` in applyStatus), so releasing on !busy hands
+  // the UI back to an observation, never to a stale one.
   // Drop the optimistic override as soon as the world agrees with it.
+  //
+  // It deliberately does NOT release while reality disagrees: during a connect
+  // the link poll can still be reporting the old state, and releasing on that
+  // flashes "Not protected" over a connect that is succeeding.
   function reconcile() {
     if (_desired === -1) return
     var real = linkActive || statusConnected
     if (real === (_desired === 1)) {
       _desired = -1
       pendingLabel = ""
+      return
+    }
+    // Safety valve only, never part of a normal connect or disconnect. If the
+    // world settles on the opposite of what was asked and stays there, the
+    // override would otherwise hold the panel at a lie for the rest of the
+    // session (a disconnect that something else immediately undoes leaves
+    // "Not protected" over a live tunnel, and the power button then tries to
+    // connect). Fifteen seconds is far longer than the few seconds a real
+    // connect needs to settle, so this can never cause a flash.
+    if (!busy && _actionEndedMs > 0 && Date.now() - _actionEndedMs > 15000) {
+      _desired = -1
+      pendingLabel = ""
     }
   }
+
 
   function applyState(text) {
     try {
       var s = JSON.parse(String(text || "{}"))
       recents = Array.isArray(s.recents) ? s.recents.slice(0, 3) : []
       nudgeDismissed = s.killSwitchNudgeDismissed === true
+      autoConnect = s.autoConnect === true
     } catch (e) {
       recents = []
       nudgeDismissed = false
+      autoConnect = false
     }
     stateLoaded = true
   }
 
   function saveState() {
-    stateFile.setText(JSON.stringify({ recents: recents, killSwitchNudgeDismissed: nudgeDismissed }))
+    stateFile.setText(JSON.stringify({
+      recents: recents,
+      killSwitchNudgeDismissed: nudgeDismissed,
+      autoConnect: autoConnect
+    }))
+  }
+
+  // ── Always On ───────────────────────────────────────────────────────────
+
+  function toggleAutoConnect() {
+    autoConnect = !autoConnect
+    _autoNextMs = 0
+    saveState()
+    autoReconcile()
+  }
+
+  // Run on every link poll, and checked against the world as it is right now.
+  //
+  // Back to the top of Recent, which is the server we were last actually on,
+  // however we got there. If that one fails it is skipped next time round, so
+  // a server that is full or gone can't stall this forever.
+  function autoReconcile() {
+    if (!autoReady) return
+    if (connected || linkActive || busy) return
+    if (_autoNextMs > 0 && Date.now() < _autoNextMs) return
+    var t = recents.length > 0 && Array.isArray(recents[0].args) ? recents[0] : null
+    if (t && !_autoPinFailed) connectTo(t.args, "Reconnecting to " + t.title + "…", t, true)
+    else connectTo([], "Reconnecting to fastest…", null, true)
   }
 
   function recordRecent(target) {
@@ -527,7 +685,11 @@ Item {
     // the configured interval once it closes.
     interval: (root.panelOpen ? 5 : root.refreshIntervalSec) * 1000
     repeat: true
-    running: root.installed && root.signedIn
+    // Not while a connect or disconnect is running: `protonvpn connect`
+    // blocks for 30-60s, and a 5s poll across that is where most of the
+    // concurrent CLI processes used to come from. delayedRefresh pulls fresh
+    // state 1.2s after the action finishes, so nothing is lost by waiting.
+    running: root.installed && root.signedIn && !root.busy
     onTriggered: root.refreshStatus()
   }
 
@@ -539,6 +701,26 @@ Item {
       root.watchLink()
       root.refreshStatus()
     }
+  }
+
+  // Start exactly one deferred probe, the moment a slot frees up, so the queue
+  // drains at the CLI's own pace rather than waiting on a timer tick.
+  // Account first: `signedIn` gates the map, the tabs and every setting.
+  function drainProbes() {
+    if (cliBusy) return
+    if (_wantAccount) { _wantAccount = false; refreshAccount(); return }
+    if (_wantConfig) { _wantConfig = false; loadConfig(); return }
+    if (_wantCountries) { _wantCountries = false; loadCountries(false); return }
+    if (_wantStatus) { _wantStatus = false; refreshStatus(); return }
+  }
+
+  // Safety net only: drainProbes() normally runs from each probe's exit.
+  Timer {
+    id: probeRetry
+    interval: 600
+    repeat: true
+    running: root._probesPending && root.installed
+    onTriggered: root.drainProbes()
   }
 
   Timer {
@@ -632,12 +814,22 @@ Item {
       if (!link.active && was) root.trafficReset()
       // A tunnel we didn't ask to close is the one thing a person must hear
       // about: the icon dimming is not a signal most people read.
+      //
+      // A connect in flight is not that. Two things take the tunnel down
+      // mid-connect and neither is news: switching servers tears the old one
+      // down first, and every `protonvpn connect` briefly double-activates,
+      // because the CLI adds the NM profile (which NetworkManager then
+      // auto-activates on its own, autoconnect defaults to yes) and then
+      // explicitly activates it, so NM preempts its own activation. Without
+      // this guard that lands as "You're no longer protected" in the middle
+      // of a connect the person just asked for.
       if (was && !link.active) {
-        if (!root._expectDown && !actionProcess.running)
+        if (!root._expectDown && !actionProcess.running && !connectProcess.running)
           root.notify("Proton VPN disconnected", "You're no longer protected.", "critical")
         root._expectDown = false
       }
       root.reconcile()
+      root.autoReconcile()
       // The tunnel came up or went away behind our back (CLI in a terminal,
       // a drop, a reconnect), pull the detail rows back in sync.
       if (was !== link.active) root.refreshStatus()
@@ -654,6 +846,8 @@ Item {
     stdout: StdioCollector { id: statusStdout; waitForEnd: true }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      root._probeRunning = false
+      Qt.callLater(root.drainProbes)
       if (exitCode === 0) {
         root.applyStatus(String(statusStdout.text || ""))
         root.lastError = ""
@@ -669,6 +863,8 @@ Item {
     command: []
     stdout: StdioCollector { id: accountStdout; waitForEnd: true }
     onExited: function(exitCode) {
+      root._probeRunning = false
+      Qt.callLater(root.drainProbes)
       // A one-off failure must not latch "signed out" forever, retry instead
       // of leaving a signed-in user staring at a sign-in prompt.
       if (exitCode !== 0) { accountRetry.restart(); return }
@@ -697,6 +893,10 @@ Item {
     command: []
     stdout: StdioCollector { id: configStdout; waitForEnd: true }
     onExited: function(exitCode) {
+      root._probeRunning = false
+      root.configPending = ""
+      root.configPendingValue = ""
+      Qt.callLater(root.drainProbes)
       if (exitCode !== 0) return
       root.config = Model.parseConfig(String(configStdout.text || ""))
       root.configLoaded = true
@@ -717,7 +917,7 @@ Item {
       root._configValue = ""
       if (exitCode !== 0) {
         if (key === "netshield" && value === "malware-ads-trackers" && Model.isPlanError(err)) {
-          root.setConfig("netshield", "malware-only")
+          root.applyConfig("netshield", "malware-only")
           return
         }
         root.lastError = Model.isPlanError(err) ? "Requires a Proton VPN Plus plan" : Model.elide(err || "Setting failed")
@@ -785,6 +985,8 @@ Item {
     command: []
     stdout: StdioCollector { id: countriesStdout; waitForEnd: true }
     onExited: function(exitCode) {
+      root._probeRunning = false
+      Qt.callLater(root.drainProbes)
       if (exitCode !== 0) return
       var list = Model.parseCountries(String(countriesStdout.text || ""))
       root.countries = list
@@ -799,11 +1001,17 @@ Item {
     stdout: StdioCollector { id: connectStdout; waitForEnd: true }
     stderr: StdioCollector { id: connectStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      root._actionEndedMs = Date.now()
       var out = String(connectStdout.text || "")
       var err = String(connectStderr.text || "")
       var target = root._target
+      var wasAuto = root._autoAttempt
       root._target = null
+      root._autoAttempt = false
       root.pendingLabel = ""
+      root._autoNextMs = wasAuto && exitCode !== 0 ? Date.now() + root.autoRetryMs : 0
+      if (exitCode === 0) root._autoPinFailed = false
+      else if (wasAuto) root._autoPinFailed = true
       if (exitCode !== 0) {
         root._desired = -1
         var text = err || out || "Connect failed"
@@ -812,14 +1020,32 @@ Item {
         actionStatusTimer.restart()
       } else {
         root.lastError = ""
-        // First line is "Connected to <server> in <city>, <country>."
-        var line = Model.elide(out.split("\n")[0] || "", 90)
+        // The confirmation line, which is not always the first one: an expired
+        // server list puts "Server list is outdated, updating..." ahead of it,
+        // and that is not what the panel or the notification should report.
+        var line = Model.elide(Model.connectedLine(out) || out.split("\n")[0] || "", 90)
         root.actionStatus = line
         actionStatusTimer.restart()
+        // Fastest, Random, P2P, Secure Core and Tor arrive here with no target
+        // because you didn't name a destination, but you still ended up
+        // somewhere. Recover it from the CLI's own confirmation line so Recent
+        // is a record of where you've been, not only of what you clicked.
+        if (!target) {
+          var landed = Model.parseConnected(out)
+          if (landed) target = {
+            key: "server:" + landed.name,
+            title: landed.city !== "" ? landed.city : landed.name,
+            subtitle: [landed.country, landed.name].filter(function(v) { return v !== "" }).join(" · "),
+            args: [landed.name]
+          }
+        }
         root.recordRecent(target)
         root.notify("Protected", line, "normal")
         root.loadCities(true)
       }
+      // Look at the link now rather than waiting up to watchIntervalSec, so
+      // the override is released against fresh data as soon as possible.
+      root.watchLink()
       delayedRefresh.restart()
     }
   }
@@ -831,6 +1057,7 @@ Item {
     stdout: StdioCollector { id: actionStdout; waitForEnd: true }
     stderr: StdioCollector { id: actionStderr; waitForEnd: true }
     onExited: function(exitCode) {
+      root._actionEndedMs = Date.now()
       var out = String(actionStdout.text || "")
       var err = String(actionStderr.text || "")
       root.pendingLabel = ""

--- a/servers.py
+++ b/servers.py
@@ -51,17 +51,37 @@ def read_cache():
         return None
 
 
-def usable(s):
+def status_known(data):
+    """Whether Status carries any information in this cache.
+
+    Proton fills Status in from a *separate* "loads" refresh
+    (`Status = 1 if server_load.enabled else 0` in its own types.py). Until
+    that call has succeeded, or when it fails, every server in the file reads
+    Status 0. That means "we don't know yet", not "all 18,000 servers are
+    down", and taking it literally empties the map and every city list.
+
+    So Status is honoured only when at least one server is marked up.
+    """
+    for s in data.get("LogicalServers") or []:
+        if s.get("Status") == 1:
+            return True
+    return False
+
+
+def usable(s, check_status=True):
     """Connectable, and not Secure Core (those are reached via --securecore)."""
-    return s.get("Status") == 1 and not ((s.get("Features") or 0) & SECURE_CORE)
+    if check_status and s.get("Status") != 1:
+        return False
+    return not ((s.get("Features") or 0) & SECURE_CORE)
 
 
 def all_cities(data):
     """Every city worldwide: one entry per (country, city) with its coordinates
     and best server. Feeds the panel's mini-map; ~200 rows for ~18k servers."""
     out = {}
+    check_status = status_known(data)
     for s in data.get("LogicalServers") or []:
-        if not usable(s):
+        if not usable(s, check_status):
             continue
         loc = s.get("Location") or {}
         lat, lon = loc.get("Lat"), loc.get("Long")
@@ -132,9 +152,11 @@ def main():
 
     # city -> best server seen so far, plus a count of that city's servers.
     cities = {}
+    check_status = status_known(data)
     for s in data.get("LogicalServers") or []:
-        # Status 0 means the server is under maintenance, not connectable.
-        if s.get("Status") != 1:
+        # Status 0 means under maintenance, but only once we know Status has
+        # been populated at all: see status_known().
+        if check_status and s.get("Status") != 1:
             continue
         if (s.get("ExitCountry") or "").upper() != code:
             continue


### PR DESCRIPTION
Closes part of #2.

## What this adds

**Always On**, a third switch on the Protection tab, off by default. Subtext:
"Reconnects on boot and interruptions".

While it's on the widget holds one invariant: if you're signed in and the
tunnel isn't up, bring it up. Booting, signing in, joining a network and a
tunnel that drops on its own are all just moments when that stops being true,
so the 4 second nmcli poll that already drives the bar icon does the whole job.
No second watcher, no second process, nothing to keep in sync.

- Target is the top of **Recent**, which is the server you were last actually
  on. If that one fails it's skipped next time and the attempt falls back to
  Fastest, so a server that's full or gone can't stall it forever.
- A failed connect waits 30 seconds before the next try, so a dead network or a
  cafe portal you haven't signed into yet doesn't get hammered.
- It never fires while you're signed out and never opens a sign-in terminal on
  its own.
- While it's on, Disconnect won't keep you disconnected. Turning the switch off
  is how you stay off. That's deliberate, there's no separate pause.

The CLI has no always-on mode of its own, and NetworkManager can't own this
either: the CLI re-creates its WireGuard profile on every connect, so an NM
autoconnect flag would only fight it.

## Naming

The UI says "Always On". The internal names stayed `autoConnect` /
`toggleAutoConnect`, and the `autoConnect` key in `state.json` was left alone
on purpose. Renaming that key would silently reset the switch to off for
anyone who already had it on.

## Fixes that came with it

Four things that were already broken and got in the way:

1. **Recent never recorded Fastest, Random, P2P, Secure Core or Tor connects.**
   Those don't name a destination when you click them, so nothing was stored
   and Always On had nothing to aim at. The server they landed on is now read
   off the CLI's "Connected to ..." line and recorded by name and city.
2. **The status row showed "Server list is outdated" instead of the server
   name**, because that line isn't always printed first and the parser assumed
   line 0.
3. **The map and the city lists emptied out** whenever Proton's cache had
   `Status` at 0 for every server. That means its loads refresh hasn't landed
   yet, not that all 18,000 servers are down. `servers.py` now honours `Status`
   only once at least one server is marked up.
4. **CLI calls weren't serialised.** Every `protonvpn` call is a fresh Python
   process that loads, and may rewrite, Proton's shared 24MB server cache
   without taking a lock on it. Two of them refreshing at once could leave every
   server in that file marked down, at which point the CLI refuses to pick a
   server at all until the list is refetched, which it won't do while its own
   copy looks fresh. Read-only probes now take turns and stand aside for actions
   you asked for, and a probe that stands aside is queued rather than dropped.
   A connect went from nine to fifteen CLI processes down to one.

## Kill Switch and NetShield feedback

Toggling either one costs two CLI runs, `config set` then the `config list`
re-read that confirms it, which is about 1.4 seconds of Python startup before
the switch can move. It used to sit there looking dead.

Both rows now say "Turning on..." or "Turning off..." in the description while
the change is in flight, held until the re-read lands so the text stops at the
same moment the switch moves. The value is never guessed at, the row keeps
showing what the CLI last reported, so what you see is always what the CLI
actually has. Both rows refuse clicks until the change settles, including from
the keyboard cursor, which bypasses the row's `enabled`.

## Testing

- Full reboot and a full shutdown, tunnel came up on its own both times.
- Toggle text and the disabled states checked against a stub service in a
  throwaway quickshell harness.
- `protonvpn config list` and the widget's `debug` output agree on both
  settings.

## Not in this PR

Issue #2 also asks for a trusted networks list, two of its acceptance criteria.
That isn't here and isn't planned as part of this, so #2 shouldn't be closed
when this merges.
