### PR TITLE
Split tunneling, and the Kill Switch fixes it needed

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -27,6 +27,31 @@ Panel {
   property int nudgeIndex: 0
   property int quickIndex: 0
   property int protectionIndex: 0
+
+  // The Protection section grows by three rows when split tunneling is on,
+  // so its cursor length and the position of the sign-out row are computed
+  // rather than counted by hand. The caption under the app list carries no
+  // cursor of its own.
+  readonly property bool splitDetailVisible: vpn.splitAvailable && vpn.splitOn && !vpn.splitBlocked
+  readonly property int protectionCount: splitDetailVisible ? 7 : 5
+  readonly property int signOutIndex: protectionCount - 1
+
+  // App paths Proton's file already holds that the scan no longer finds, kept
+  // as options so an app removed from the system can still be unticked.
+  readonly property var splitStaleApps: {
+    var chosen = vpn.splitApps
+    var out = []
+    for (var i = 0; i < chosen.length; i++) {
+      var path = String(chosen[i])
+      var name = path.split("/").pop()
+      out.push({ value: path, label: name, description: path })
+    }
+    return out
+  }
+
+  onSplitDetailVisibleChanged: {
+    if (protectionIndex >= protectionCount) protectionIndex = protectionCount - 1
+  }
   property int recentIndex: 0
   property int countryIndex: 0
   property int serverIndex: 0
@@ -97,7 +122,7 @@ Panel {
     list.push({ name: "quick", count: quickActions.length })
     list.push({ name: "tabs", count: tabs.length })
     if (tab === "protection") {
-      list.push({ name: "protection", count: 4 })
+      list.push({ name: "protection", count: protectionCount })
     } else {
       if (vpn.recents.length > 0) list.push({ name: "recents", count: vpn.recents.length })
       if (drilled) list.push({ name: "servers", count: serverRowCount })
@@ -247,6 +272,9 @@ Panel {
       if (protectionIndex === 0) vpn.toggleKillSwitch()
       else if (protectionIndex === 1) vpn.toggleNetShield()
       else if (protectionIndex === 2) vpn.toggleAutoConnect()
+      else if (protectionIndex === 3) vpn.toggleSplitTunnel()
+      else if (splitDetailVisible && protectionIndex === 4) splitModeRow.toggle()
+      else if (splitDetailVisible && protectionIndex === 5) splitAppsRow.toggle()
       else requestSignOut()
     }
     else if (focusSection === "recents") { vpn.connectRecent(recentIndex); showConnection() }
@@ -345,8 +373,9 @@ Panel {
     else if (focusSection === "servers") column = serverColumn
     var i = sectionIndex(focusSection)
     // The Protection column carries the Account header and rows after its
-    // three switches; the sign-out row is its last child.
-    if (focusSection === "protection" && i === 3 && column) i = column.children.length - 1
+    // switches; the sign-out row is its last child wherever the cursor for it
+    // has ended up.
+    if (focusSection === "protection" && i === signOutIndex && column) i = column.children.length - 1
     if (column && i >= 0 && i < column.children.length) scrollItemIntoView(column.children[i])
   }
 
@@ -432,6 +461,8 @@ Panel {
         busy: vpn.busy,
         killSwitch: vpn.config["kill-switch"] || "",
         configPending: vpn.configPending,
+        splitTunneling: vpn.splitOn ? vpn.splitMode : "off",
+        splitApps: vpn.splitApps.length,
         netshield: vpn.config["netshield"] || "",
         countries: vpn.countries.length,
         recents: vpn.recents.length,
@@ -912,6 +943,72 @@ Panel {
                 onClicked: { root.clearHighlight(); vpn.toggleAutoConnect() }
               }
 
+              // Proton skips split tunneling entirely while the kill switch
+              // is on, so the row says that instead of offering a switch that
+              // would look on and do nothing.
+              Toggle {
+                width: parent.width
+                label: "Split tunneling"
+                description: vpn.splitDescription()
+                checked: vpn.splitOn
+                enabled: vpn.splitAvailable && !vpn.splitBlocked
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursor("protection", 3) }
+                onClicked: { root.clearHighlight(); vpn.toggleSplitTunnel() }
+              }
+
+              Dropdown {
+                id: splitModeRow
+                visible: root.splitDetailVisible
+                width: parent.width
+                label: "Mode"
+                value: vpn.splitMode
+                options: [
+                  { value: "exclude", label: "Exclude: chosen apps skip the VPN" },
+                  { value: "include", label: "Include: only chosen apps use the VPN" }
+                ]
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 4
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursor("protection", 4) }
+                onChanged: function(value) { vpn.setSplitMode(value) }
+              }
+
+              // The list is scanned fresh each time the popup opens, so an app
+              // installed since the panel loaded is there without a restart.
+              // Paths already in Proton's file that no longer scan (an app
+              // that was removed) are added back as options, otherwise they
+              // could never be unticked.
+              MultiSelect {
+                id: splitAppsRow
+                visible: root.splitDetailVisible
+                width: parent.width
+                label: "Apps"
+                values: vpn.splitApps
+                options: root.splitStaleApps
+                optionsCommand: ["python3", vpn.appsScriptPath]
+                placeholderText: "Search apps..."
+                emptyText: "No apps found"
+                noSelectionText: "None chosen"
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 5
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursor("protection", 5) }
+                onChanged: function(values) { vpn.setSplitApps(values) }
+              }
+
+              Text {
+                visible: root.splitDetailVisible
+                width: parent.width
+                text: "Restart each chosen app after connecting, or it keeps using the tunnel it started on."
+                color: Qt.darker(root.foreground, 1.5)
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+                wrapMode: Text.WordWrap
+              }
+
               // ── Account ─────────────────────────────────────────────────
               PanelSectionHeader {
                 text: "ACCOUNT"
@@ -929,12 +1026,12 @@ Panel {
 
               ActionRow {
                 width: parent.width
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === root.signOutIndex
                 icon: "󰍃"
                 title: root.signOutArmed ? "Click again to sign out" : "Sign out"
                 subtitle: root.signOutArmed ? "Disconnects and clears the session on this computer" : "You'll need your password and 2FA to sign back in"
                 enabled: !vpn.busy
-                onEntered: root.setCursor("protection", 3)
+                onEntered: root.setCursor("protection", root.signOutIndex)
                 onClicked: root.requestSignOut()
               }
             }

--- a/Panel.qml
+++ b/Panel.qml
@@ -986,7 +986,6 @@ Panel {
                 visible: root.splitDetailVisible
                 width: parent.width
                 label: "Apps"
-                values: vpn.splitApps
                 options: root.splitStaleApps
                 optionsCommand: ["python3", vpn.appsScriptPath]
                 placeholderText: "Search apps..."
@@ -997,6 +996,20 @@ Panel {
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursor("protection", 5) }
                 onChanged: function(values) { vpn.setSplitApps(values) }
+              }
+
+              // MultiSelect writes to its own `values` when a row is ticked,
+              // and that imperative write destroys a plain declarative
+              // binding: from the first tick on, the list would show what was
+              // clicked rather than what is in the file. The visible symptom
+              // was a mode switch leaving the previous mode's apps on screen
+              // while Proton had none, which reads as "it kept my apps" when
+              // the truth is the opposite. Binding reasserts itself every time
+              // the service's list changes, so the file stays the one source.
+              Binding {
+                target: splitAppsRow
+                property: "values"
+                value: vpn.splitApps
               }
 
               Text {

--- a/Panel.qml
+++ b/Panel.qml
@@ -33,9 +33,11 @@ Panel {
   // rather than counted by hand. The caption under the app list carries no
   // cursor of its own.
   readonly property bool splitDetailVisible: vpn.splitActive
-  // The service is a private child of this panel, so this is what a harness
-  // can read to check the Kill Switch actually moved.
+  // The service and the dialog are private children of this panel; these are
+  // what a harness needs to check the Kill Switch actually moved, and that it
+  // asked first.
   readonly property string vpnKs: vpn.config["kill-switch"] || ""
+  readonly property alias killSwitchDialog: killSwitchConfirm
   readonly property int protectionCount: splitDetailVisible ? 7 : 5
   readonly property int signOutIndex: protectionCount - 1
 
@@ -66,8 +68,6 @@ Panel {
   // Sign out is destructive (it disconnects too), so it takes two clicks
   // within five seconds.
   property bool signOutArmed: false
-  // Same idea, for the Kill Switch: see requestKillSwitch().
-  property bool killSwitchArmed: false
 
   // Drilled into one country's server list rather than the country list.
   readonly property bool drilled: vpn.serversCountry !== ""
@@ -96,6 +96,7 @@ Panel {
   // switch off, which means a dropped tunnel silently exposes the user.
   readonly property bool nudgeVisible: vpn.signedIn && vpn.configLoaded && vpn.stateLoaded
                                        && !vpn.killSwitchOn && !vpn.nudgeDismissed
+                                       && !vpn.splitActive
 
   readonly property string heroMeta: {
     if (!vpn.installed) return vpn.installing ? "Installing…" : "Not installed"
@@ -323,21 +324,14 @@ Panel {
     if (panelFlick) panelFlick.contentY = 0
   }
 
-  // Turning the Kill Switch on quietly pauses split tunneling, because Proton
-  // ignores split tunneling whenever the Kill Switch is on. Nobody could be
-  // expected to work that out from looking at two switches, so the row asks
-  // once first, exactly the way signing out does. Only that direction asks:
-  // turning the Kill Switch off restores split tunneling, which is not a
-  // surprise worth stopping anyone for.
+  // Disconnected there is nothing to interrupt, so the change just happens.
+  // Connected, it costs a reconnect, and that is what the dialog is for.
   function requestKillSwitch() {
-    if (vpn.splitActive && !vpn.killSwitchOn) {
-      if (!killSwitchArmed) { killSwitchArmed = true; killSwitchArm.restart(); return }
-    }
-    killSwitchArmed = false
-    vpn.toggleKillSwitch()
+    if (vpn.splitActive) return
+    if (!vpn.connected) { vpn.toggleKillSwitch(); return }
+    killSwitchConfirm.selectedIndex = 0
+    killSwitchConfirm.opened = true
   }
-
-  Timer { id: killSwitchArm; interval: 5000; onTriggered: root.killSwitchArmed = false }
 
   function requestSignOut() {
     if (!signOutArmed) { signOutArmed = true; signOutArm.restart(); return }
@@ -547,17 +541,53 @@ Panel {
       // letter typed would drive the cursor instead of the input.
       blocked: filterField.activeFocus || usernameField.activeFocus
       onMoveRequested: function(dx, dy) {
+        // A dialog with the screen dimmed behind it owns the keyboard, or the
+        // cursor would be moving around underneath it unseen.
+        if (killSwitchConfirm.opened) {
+          killSwitchConfirm.selectedIndex = killSwitchConfirm.selectedIndex === 0 ? 1 : 0
+          return
+        }
         if (!root.cursorActive) { root.cursorActive = true; return }
         root.moveCursor(dx, dy)
       }
-      onActivateRequested: if (root.cursorActive) root.activateCursor()
+      onActivateRequested: {
+        if (killSwitchConfirm.opened) {
+          if (killSwitchConfirm.selectedIndex === 0) killSwitchConfirm.canceled()
+          else killSwitchConfirm.confirmed()
+          return
+        }
+        if (root.cursorActive) root.activateCursor()
+      }
       // Inside a drill, escape backs out one level before it closes the panel.
-      onCloseRequested: root.drilled ? root.drillOut() : root.close()
+      onCloseRequested: {
+        if (killSwitchConfirm.opened) { killSwitchConfirm.canceled(); return }
+        root.drilled ? root.drillOut() : root.close()
+      }
       onTabRequested: function(direction) { root.switchPanel(direction) }
       // No single-letter actions on purpose: the panel takes keyboard focus
       // when it opens, and a stray keystroke must never change the tunnel.
       onTextKey: function(t) {
         if (t === "/") filterField.forceActiveFocus()
+      }
+
+      // Changing the Kill Switch means dropping the tunnel and putting it
+      // back, and for those seconds nothing is protected. That is a real cost
+      // and the person paying it should agree to it first, so this asks rather
+      // than doing it and narrating afterwards. Cancel is preselected: the
+      // safe answer should be the one an accidental Return gives you.
+      ConfirmDialog {
+        id: killSwitchConfirm
+        anchors.fill: parent
+        z: 100
+        message: (vpn.killSwitchOn ? "Turning the Kill Switch off" : "Turning the Kill Switch on")
+          + " needs the tunnel down. You'll be disconnected and reconnected to the same server, "
+          + "and until it comes back your traffic isn't protected."
+        cancelText: "Cancel"
+        confirmText: vpn.killSwitchOn ? "Turn off" : "Turn on"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        onCanceled: opened = false
+        onConfirmed: { opened = false; vpn.toggleKillSwitch() }
       }
 
       Flickable {
@@ -923,14 +953,13 @@ Panel {
                 description: {
                   var applying = vpn.configPendingLabel("kill-switch")
                   if (applying !== "") return applying
-                  if (root.killSwitchArmed) return "Click again, this pauses split tunneling"
                   if (!vpn.configLoaded) return "Loading…"
-                  if (vpn.splitActive) return "Blocks internet if the VPN drops, pauses split tunneling"
+                  if (vpn.splitActive) return "Turn split tunneling off to use this"
                   if (vpn.connected) return "Blocks internet if the VPN drops, changing it reconnects"
                   return "Block internet if the VPN drops"
                 }
                 checked: vpn.killSwitchOn
-                enabled: vpn.configLoaded && vpn.configPending === ""
+                enabled: vpn.configLoaded && vpn.configPending === "" && !vpn.splitActive
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 0
                 foreground: root.foreground
                 fontFamily: root.fontFamily

--- a/Panel.qml
+++ b/Panel.qml
@@ -33,6 +33,9 @@ Panel {
   // rather than counted by hand. The caption under the app list carries no
   // cursor of its own.
   readonly property bool splitDetailVisible: vpn.splitActive
+  // The service is a private child of this panel, so this is what a harness
+  // can read to check the Kill Switch actually moved.
+  readonly property string vpnKs: vpn.config["kill-switch"] || ""
   readonly property int protectionCount: splitDetailVisible ? 7 : 5
   readonly property int signOutIndex: protectionCount - 1
 
@@ -63,6 +66,8 @@ Panel {
   // Sign out is destructive (it disconnects too), so it takes two clicks
   // within five seconds.
   property bool signOutArmed: false
+  // Same idea, for the Kill Switch: see requestKillSwitch().
+  property bool killSwitchArmed: false
 
   // Drilled into one country's server list rather than the country list.
   readonly property bool drilled: vpn.serversCountry !== ""
@@ -265,11 +270,11 @@ Panel {
     if (focusSection === "install") vpn.installCli()
     else if (focusSection === "signin") submitSignIn()
     else if (focusSection === "header") vpn.toggle()
-    else if (focusSection === "nudge") { if (nudgeIndex === 0) vpn.toggleKillSwitch(); else vpn.dismissNudge() }
+    else if (focusSection === "nudge") { if (nudgeIndex === 0) requestKillSwitch(); else vpn.dismissNudge() }
     else if (focusSection === "quick") runQuick(quickActions[quickIndex].key)
     else if (focusSection === "tabs") setTab(tabs[tabIndex].key)
     else if (focusSection === "protection") {
-      if (protectionIndex === 0) vpn.toggleKillSwitch()
+      if (protectionIndex === 0) requestKillSwitch()
       else if (protectionIndex === 1) vpn.toggleNetShield()
       else if (protectionIndex === 2) vpn.toggleAutoConnect()
       else if (protectionIndex === 3) vpn.toggleSplitTunnel()
@@ -317,6 +322,22 @@ Panel {
     focusSection = "header"
     if (panelFlick) panelFlick.contentY = 0
   }
+
+  // Turning the Kill Switch on quietly pauses split tunneling, because Proton
+  // ignores split tunneling whenever the Kill Switch is on. Nobody could be
+  // expected to work that out from looking at two switches, so the row asks
+  // once first, exactly the way signing out does. Only that direction asks:
+  // turning the Kill Switch off restores split tunneling, which is not a
+  // surprise worth stopping anyone for.
+  function requestKillSwitch() {
+    if (vpn.splitActive && !vpn.killSwitchOn) {
+      if (!killSwitchArmed) { killSwitchArmed = true; killSwitchArm.restart(); return }
+    }
+    killSwitchArmed = false
+    vpn.toggleKillSwitch()
+  }
+
+  Timer { id: killSwitchArm; interval: 5000; onTriggered: root.killSwitchArmed = false }
 
   function requestSignOut() {
     if (!signOutArmed) { signOutArmed = true; signOutArm.restart(); return }
@@ -802,7 +823,7 @@ Panel {
                   foreground: root.foreground
                   hasCursor: root.cursorActive && root.focusSection === "nudge" && root.nudgeIndex === 0
                   enabled: vpn.configPending === ""
-                  onClicked: vpn.toggleKillSwitch()
+                  onClicked: root.requestKillSwitch()
                 }
 
                 Button {
@@ -896,15 +917,25 @@ Panel {
               Toggle {
                 width: parent.width
                 label: "Kill Switch"
-                description: vpn.configPendingLabel("kill-switch")
-                  || (vpn.configLoaded ? "Block internet if the VPN drops" : "Loading…")
+                // Says what the click will cost before it is clicked: pausing
+                // split tunneling, or a reconnect, both of which used to be
+                // things you found out afterwards.
+                description: {
+                  var applying = vpn.configPendingLabel("kill-switch")
+                  if (applying !== "") return applying
+                  if (root.killSwitchArmed) return "Click again, this pauses split tunneling"
+                  if (!vpn.configLoaded) return "Loading…"
+                  if (vpn.splitActive) return "Blocks internet if the VPN drops, pauses split tunneling"
+                  if (vpn.connected) return "Blocks internet if the VPN drops, changing it reconnects"
+                  return "Block internet if the VPN drops"
+                }
                 checked: vpn.killSwitchOn
                 enabled: vpn.configLoaded && vpn.configPending === ""
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 0
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursor("protection", 0) }
-                onClicked: { root.clearHighlight(); vpn.toggleKillSwitch() }
+                onClicked: { root.clearHighlight(); root.requestKillSwitch() }
               }
 
               Toggle {

--- a/Panel.qml
+++ b/Panel.qml
@@ -32,7 +32,7 @@ Panel {
   // so its cursor length and the position of the sign-out row are computed
   // rather than counted by hand. The caption under the app list carries no
   // cursor of its own.
-  readonly property bool splitDetailVisible: vpn.splitAvailable && vpn.splitOn && !vpn.splitBlocked
+  readonly property bool splitDetailVisible: vpn.splitActive
   readonly property int protectionCount: splitDetailVisible ? 7 : 5
   readonly property int signOutIndex: protectionCount - 1
 
@@ -950,7 +950,7 @@ Panel {
                 width: parent.width
                 label: "Split tunneling"
                 description: vpn.splitDescription()
-                checked: vpn.splitOn
+                checked: vpn.splitActive
                 enabled: vpn.splitAvailable && !vpn.splitBlocked
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
                 foreground: root.foreground

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Two switches saved to Proton's own settings:
   plan Proton only allows malware blocking; the widget steps down to that
   automatically.
 
+- **Split tunneling**: pick apps that skip the VPN, or flip it round so only
+  the apps you pick use it. See below, it has more rules attached than the
+  other two.
+
 And one saved by the widget itself, because the CLI has no setting for it:
 
 - **Always On**: whenever Proton isn't connected, connect it. That covers
@@ -224,6 +228,37 @@ And one saved by the widget itself, because the CLI has no setting for it:
   will never open a sign-in terminal on its own. And while it's on, the
   **Disconnect** button won't keep you disconnected, you'll be reconnected
   within a few seconds; switch Always On off if you want to stay off.
+
+#### Split tunneling
+
+Turn it on and two more rows appear: **Mode**, and the **Apps** list.
+
+- **Exclude** (the default) sends the apps you pick out through your normal
+  connection, everything else stays on the VPN. Good for a bank that blocks
+  VPN IPs, or a device on your own network.
+- **Include** is the mirror image: only the apps you pick go through the VPN
+  and everything else uses your normal connection.
+
+The Apps list is every desktop app on the machine that the widget can point at
+a real program on disk. Search it, tick what you want, untick to remove.
+
+Four things to know, all of them Proton's behaviour rather than the widget's:
+
+- **It needs the Kill Switch off.** Proton skips split tunneling entirely while
+  the Kill Switch is on, so the row says so and stays locked until you turn the
+  Kill Switch off. Changing the Kill Switch needs you disconnected first, so
+  the order is: disconnect, Kill Switch off, set up split tunneling, connect.
+  It's a real trade, a tunnel with holes in it can't also promise nothing
+  leaks when it drops.
+- **Restart your apps after connecting.** Proton tags an app's connections as
+  they're made, so anything already running when the tunnel came up keeps using
+  it until you restart it. Proton's own app tells you the same thing.
+- **Apps only, no IP ranges.** Proton's settings file has a field for IP ranges
+  but nothing on Linux reads it yet, so the widget doesn't offer one rather
+  than write a setting that does nothing.
+- **Flatpaks and Snaps aren't listed.** They all launch through one shared
+  runner, so picking one would pick all of them. Same for anything that
+  launches through a terminal chooser or a web-app handler.
 
 Below the switches, **Account** shows who's signed in and the plan, with a
 **Sign out** row, it asks for a second click within five seconds, because
@@ -342,9 +377,11 @@ Omarchy plugin. It:
 - reads Proton's server cache read-only (city list, coordinates, and the map's
   connected-city lookup all come from it), reads the tunnel's byte counters
   under `/sys/class/net/` once a second while the panel is open, and writes
-  exactly one file of its own
+  one file of its own
   (`~/.local/state/omarchy-protonvpn/state.json`: recent location labels,
   whether you dismissed the Kill Switch prompt, and whether Always On is on)
+- writes one file that isn't its own, and only if you turn split tunneling on:
+  `~/.config/Proton/VPN/settings.json`, Proton's own settings. Rules below.
 
 **Sign-in.** Your password and 2FA code go straight to the `protonvpn` CLI's
 own prompt in a terminal; this plugin never sees them. The username you type in
@@ -358,6 +395,25 @@ terminal runs non-interactively, so nothing lands in your shell history.
 `protonvpn config set`. The widget will only ever pass `kill-switch` ∈
 `{off, standard}` and `netshield` ∈ `{off, malware-only, malware-ads-trackers}`;
 no other key or value can reach the CLI from this code.
+
+**Writing Proton's settings file.** Split tunneling is the one feature with no
+CLI command behind it, so the widget edits `~/.config/Proton/VPN/settings.json`
+itself. What that means in practice:
+
+- It only ever happens when you change something under Split tunneling.
+  Nothing is written on start-up, on a poll, or when you connect.
+- The file is read fresh, only `features.split_tunneling` is changed, and every
+  other key is handed back exactly as found. A diff before and after a change
+  shows the app list and nothing else.
+- If the file is missing or unreadable, nothing is written and the row says
+  "Sign in and connect once first". The widget never creates it.
+- App paths only ever come from the widget's own scan of installed apps, and
+  anything that isn't an absolute path is dropped rather than repaired.
+- Writes are atomic (written aside, then renamed into place), so an interrupted
+  write can't leave you with half a settings file.
+- Nothing is written while the Kill Switch is on, since Proton would ignore it,
+  and nothing is written while a `protonvpn config set` is still running, so
+  the two can't land on the file at once.
 
 **What's visible to other processes.** Omarchy exposes every plugin over a
 Quickshell IPC socket under `/run/user/<uid>/`, which only your own user (and

--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ Two switches saved to Proton's own settings:
   and all you'd see is the icon dimming. The CLI ships with it **off**: which is
   why the panel offers to turn it on the first time you sign in.
 
+  If split tunneling is on, turning the Kill Switch on pauses it, so the row
+  asks for a second click before it does that, the same way signing out does.
+
   Proton won't change this setting while a tunnel is up, so if you flip it
   while connected the widget drops the tunnel, makes the change, and puts you
   back on the same server. That takes as long as a normal connect, and the row

--- a/README.md
+++ b/README.md
@@ -264,6 +264,13 @@ Four things to know, all of them Proton's behaviour rather than the widget's:
 - **Apps only, no IP ranges.** Proton's settings file has a field for IP ranges
   but nothing on Linux reads it yet, so the widget doesn't offer one rather
   than write a setting that does nothing.
+- **IPv4 only.** Proton tags IPv4 connections and nothing else, so an app you
+  excluded still uses the VPN for anything it sends over IPv6, and in Include
+  mode an app you left out still uses the VPN over IPv6. If you need an
+  exclusion to be absolute, `protonvpn config set ipv6 off` stops the tunnel
+  carrying IPv6 at all and apps fall back to IPv4, where it works. When you
+  test this, check with `curl -4`, otherwise you may be looking at a path
+  split tunneling never touches.
 - **Flatpaks and Snaps aren't listed.** They all launch through one shared
   runner, so picking one would pick all of them. Same for anything that
   launches through a terminal chooser or a web-app handler.

--- a/README.md
+++ b/README.md
@@ -262,8 +262,9 @@ Four things to know, all of them Proton's behaviour rather than the widget's:
 - **It needs the Kill Switch off.** Proton skips split tunneling entirely while
   the Kill Switch is on, so the row says so and stays locked until you turn the
   Kill Switch off. The switch shows off while that's true, because nothing is
-  being split, and it says it's paused rather than off: your app lists are
-  kept, so turning the Kill Switch back off brings the whole setup back. Changing the Kill Switch needs you disconnected first, so
+  being split, and it stays off when you turn the Kill Switch back off. Your
+  app lists are kept either way, so turning it back on is one click. Neither
+  switch ever turns itself on. Changing the Kill Switch needs you disconnected first, so
   the order is: disconnect, Kill Switch off, set up split tunneling, connect.
   It's a real trade, a tunnel with holes in it can't also promise nothing
   leaks when it drops.

--- a/README.md
+++ b/README.md
@@ -200,12 +200,16 @@ Two switches saved to Proton's own settings:
   and all you'd see is the icon dimming. The CLI ships with it **off**: which is
   why the panel offers to turn it on the first time you sign in.
 
-  If split tunneling is on, turning the Kill Switch on pauses it, so the row
-  asks for a second click before it does that, the same way signing out does.
+  The Kill Switch and split tunneling can't both be on, because Proton ignores
+  split tunneling whenever the Kill Switch is on. Each row locks the other and
+  says which one to turn off, so you never have to know the rule.
 
   Proton won't change this setting while a tunnel is up, so if you flip it
   while connected the widget drops the tunnel, makes the change, and puts you
-  back on the same server. That takes as long as a normal connect, and the row
+  back on the same server. It asks first, in a dialog, because your traffic
+  isn't protected until the tunnel is back and that's your call to make, not
+  something to be told about afterwards. Cancel is preselected. Disconnected
+  there's nothing to interrupt, so it just changes. That takes as long as a normal connect, and the row
   says "Turning on…" the whole way through. Always On is held off in the
   middle, otherwise it would reconnect into the gap and the change would fail.
   If anything goes wrong, you end up back on the VPN with the setting

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ Two switches saved to Proton's own settings:
   Without this, a dropped tunnel silently falls back to your plain connection
   and all you'd see is the icon dimming. The CLI ships with it **off**: which is
   why the panel offers to turn it on the first time you sign in.
+
+  Proton won't change this setting while a tunnel is up, so if you flip it
+  while connected the widget drops the tunnel, makes the change, and puts you
+  back on the same server. That takes as long as a normal connect, and the row
+  says "Turning on…" the whole way through. Always On is held off in the
+  middle, otherwise it would reconnect into the gap and the change would fail.
+  If anything goes wrong, you end up back on the VPN with the setting
+  unchanged, never stranded off it.
 - **NetShield**: blocks malware, ads, and trackers at the DNS level. On a free
   plan Proton only allows malware blocking; the widget steps down to that
   automatically.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,9 @@ Four things to know, all of them Proton's behaviour rather than the widget's:
 
 - **It needs the Kill Switch off.** Proton skips split tunneling entirely while
   the Kill Switch is on, so the row says so and stays locked until you turn the
-  Kill Switch off. Changing the Kill Switch needs you disconnected first, so
+  Kill Switch off. The switch shows off while that's true, because nothing is
+  being split, and it says it's paused rather than off: your app lists are
+  kept, so turning the Kill Switch back off brings the whole setup back. Changing the Kill Switch needs you disconnected first, so
   the order is: disconnect, Kill Switch off, set up split tunneling, connect.
   It's a real trade, a tunnel with holes in it can't also promise nothing
   leaks when it drops.

--- a/Service.qml
+++ b/Service.qml
@@ -410,11 +410,9 @@ Item {
     if (!splitLoaded) return "Loading…"
     if (!splitAvailable) return "Sign in and connect once first"
     if (!configLoaded) return "Loading…"
-    if (splitBlocked) {
-      return splitOn
-        ? "Paused while the Kill Switch is on, your apps are kept"
-        : "Turn the Kill Switch off to use this"
-    }
+    // One sentence for both cases: nothing "pauses" any more, so nothing
+    // should hint that it will come back on its own.
+    if (splitBlocked) return "Turn the Kill Switch off to use this"
     if (splitError !== "") return splitError
     if (!splitOn) return "Keep chosen apps off the VPN"
     var n = splitApps.length
@@ -436,13 +434,17 @@ Item {
   // `mutate` receives the current `features.split_tunneling` object and
   // changes it in place. Everything else in the file is whatever the last
   // read produced, untouched.
-  function writeSplit(mutate) {
+  // `evenWhenBlocked` is only for turning split tunneling off. Turning it on
+  // while the kill switch is on would write a setting Proton ignores, but
+  // turning it off is always honest, and is how the file is kept in step with
+  // what the panel has been showing.
+  function writeSplit(mutate, evenWhenBlocked) {
     if (!splitAvailable) return false
     // Proton ignores split tunneling entirely while the kill switch is on, so
     // a write then would be a setting that reads as live and does nothing.
     // Checked here rather than per caller, because the panel's rows are not
     // the only way in: the keyboard cursor calls these functions directly.
-    if (splitBlocked) return false
+    if (splitBlocked && evenWhenBlocked !== true) return false
     // The CLI rewrites this same file, so never write across one of its runs.
     if (busy || setConfigProcess.running || configPending !== "") return false
 
@@ -529,6 +531,16 @@ Item {
     // keyboard cursor calls this directly and never sees `enabled`.
     if (splitActive) return
     var value = killSwitchOn ? "off" : "standard"
+
+    // For as long as the kill switch has been on, the panel has shown split
+    // tunneling as off, because Proton was ignoring it. The flag in Proton's
+    // file can still say otherwise, and turning the kill switch off would
+    // then bring split tunneling back on its own, which reads as a switch
+    // flipping itself. So make the file agree with what the panel has been
+    // saying. Both app lists are untouched, so one click puts it back.
+    if (value === "off" && splitOn) {
+      writeSplit(function(st) { st["enabled"] = false }, true)
+    }
     // Nothing to work around while the tunnel is down: one CLI call, as before.
     if (!connected && !linkActive) { setConfig("kill-switch", value); return }
     if (_ksCycle || configPending !== "" || busy) return

--- a/Service.qml
+++ b/Service.qml
@@ -363,6 +363,12 @@ Item {
   // first `config list` lands.
   readonly property bool splitBlocked: !configLoaded || killSwitchOn
   readonly property bool splitOn: splitAvailable && splitSection()["enabled"] === true
+  // Whether split tunneling is actually in force, which is not the same as
+  // the flag in the file. With the kill switch on, Proton ignores the setting
+  // entirely, and a switch sitting in the on position while nothing is being
+  // split is the panel telling a comfortable lie. The setting itself is left
+  // alone, so turning the kill switch back off brings it back with its apps.
+  readonly property bool splitActive: splitAvailable && splitOn && !splitBlocked
   readonly property string splitMode: {
     var m = String(splitSection()["mode"] || "exclude")
     return m === "include" ? "include" : "exclude"
@@ -404,7 +410,11 @@ Item {
     if (!splitLoaded) return "Loading…"
     if (!splitAvailable) return "Sign in and connect once first"
     if (!configLoaded) return "Loading…"
-    if (splitBlocked) return "Turn the Kill Switch off to use this"
+    if (splitBlocked) {
+      return splitOn
+        ? "Paused while the Kill Switch is on, your apps are kept"
+        : "Turn the Kill Switch off to use this"
+    }
     if (splitError !== "") return splitError
     if (!splitOn) return "Keep chosen apps off the VPN"
     var n = splitApps.length

--- a/Service.qml
+++ b/Service.qml
@@ -130,6 +130,7 @@ Item {
   readonly property string statePath: stateDir + "/state.json"
 
   readonly property string scriptPath: Qt.resolvedUrl("servers.py").toString().replace(/^file:\/\//, "")
+  readonly property string appsScriptPath: Qt.resolvedUrl("apps.py").toString().replace(/^file:\/\//, "")
 
   property string actionStatus: ""
   property string lastError: ""
@@ -327,6 +328,175 @@ Item {
     lastError = ""
     setConfigProcess.command = ["protonvpn", "config", "set", key, value]
     setConfigProcess.running = true
+  }
+
+  // ── Split tunneling ─────────────────────────────────────────────────────
+  // Proton has no CLI command for this, so the widget edits Proton's own
+  // settings file. That is the only file we write that isn't ours, so the
+  // rules are strict: read it fresh, change nothing outside
+  // `features.split_tunneling`, hand every other key back exactly as found,
+  // and never create the file. A missing or unreadable file means Proton
+  // has not run here yet, and we say so rather than invent one.
+  //
+  // Nothing pushes the file at the daemon on its own. The connector reads it
+  // whenever it starts, so the `protonvpn status` we already run is what
+  // applies a change to a live tunnel; with the tunnel down it lands on the
+  // next connect either way.
+  //
+  // Two limits come from Proton, not from us. Split tunneling is skipped
+  // entirely while the kill switch is on, and an app that was already
+  // running when the tunnel came up keeps using it until it restarts,
+  // because sockets are marked as they are created.
+  readonly property string protonSettingsPath:
+    (Quickshell.env("XDG_CONFIG_HOME") || (Quickshell.env("HOME") + "/.config"))
+    + "/Proton/VPN/settings.json"
+
+  // The whole parsed file, or null when there isn't a readable one.
+  property var protonSettings: null
+  property bool splitLoaded: false
+  property string splitError: ""
+
+  readonly property bool splitAvailable: splitLoaded && protonSettings !== null
+  // Blocked until the CLI has told us the kill switch is off, not merely
+  // until it has told us it is on: an unread config is not permission to
+  // write, and the row would otherwise be live for the second before the
+  // first `config list` lands.
+  readonly property bool splitBlocked: !configLoaded || killSwitchOn
+  readonly property bool splitOn: splitAvailable && splitSection()["enabled"] === true
+  readonly property string splitMode: {
+    var m = String(splitSection()["mode"] || "exclude")
+    return m === "include" ? "include" : "exclude"
+  }
+  // App paths for the mode in force. Proton keeps a separate list per mode
+  // and remembers both, so switching modes doesn't discard the other one.
+  readonly property var splitApps: splitAppsFor(splitMode)
+
+  function readProtonSettings(text) {
+    var data = null
+    try { data = JSON.parse(text) } catch (e) { data = null }
+    // Unparsable is treated exactly like missing: we don't rewrite a file we
+    // couldn't read, because that would throw away whatever is in it.
+    protonSettings = (data && typeof data === "object" && data["features"]) ? data : null
+    splitLoaded = true
+  }
+
+  function splitSection() {
+    if (!protonSettings) return ({})
+    var f = protonSettings["features"]
+    var st = f ? f["split_tunneling"] : null
+    return st ? st : ({})
+  }
+
+  function splitAppsFor(mode) {
+    var byMode = splitSection()["config_by_mode"]
+    var cfg = byMode ? byMode[mode] : null
+    var paths = cfg ? cfg["app_paths"] : null
+    if (!paths || typeof paths.length !== "number") return []
+    var out = []
+    for (var i = 0; i < paths.length; i++) out.push(String(paths[i]))
+    return out
+  }
+
+  // What the Split tunneling row says under its label. Here rather than in
+  // the panel because every branch of it is a state this file owns, the same
+  // way configPendingLabel() is.
+  function splitDescription() {
+    if (!splitLoaded) return "Loading…"
+    if (!splitAvailable) return "Sign in and connect once first"
+    if (!configLoaded) return "Loading…"
+    if (splitBlocked) return "Turn the Kill Switch off to use this"
+    if (splitError !== "") return splitError
+    if (!splitOn) return "Keep chosen apps off the VPN"
+    var n = splitApps.length
+    if (n === 0) return "No apps chosen yet"
+    if (splitMode === "include")
+      return n === 1 ? "Only 1 app uses the VPN" : "Only " + n + " apps use the VPN"
+    return n === 1 ? "1 app skips the VPN" : n + " apps skip the VPN"
+  }
+
+  function applySplitSettings() {
+    // Only a running connector reads the file, so this is what makes a
+    // change take hold now instead of at the next connect.
+    if (linkActive) refreshStatus()
+  }
+
+  // Every split tunneling change funnels through here, so the read-modify-
+  // write rules live in exactly one place.
+  //
+  // `mutate` receives the current `features.split_tunneling` object and
+  // changes it in place. Everything else in the file is whatever the last
+  // read produced, untouched.
+  function writeSplit(mutate) {
+    if (!splitAvailable) return false
+    // Proton ignores split tunneling entirely while the kill switch is on, so
+    // a write then would be a setting that reads as live and does nothing.
+    // Checked here rather than per caller, because the panel's rows are not
+    // the only way in: the keyboard cursor calls these functions directly.
+    if (splitBlocked) return false
+    // The CLI rewrites this same file, so never write across one of its runs.
+    if (busy || setConfigProcess.running || configPending !== "") return false
+
+    var raw = protonFile.text()
+    var data = null
+    try { data = JSON.parse(raw) } catch (e) { data = null }
+    if (!data || typeof data !== "object" || !data["features"]) {
+      splitError = "Could not read Proton's settings"
+      return false
+    }
+
+    var st = data["features"]["split_tunneling"]
+    if (!st || typeof st !== "object") {
+      splitError = "Could not read Proton's settings"
+      return false
+    }
+    if (!st["config_by_mode"]) {
+      st["config_by_mode"] = {
+        "exclude": { "mode": "exclude", "app_paths": [], "ip_ranges": [] },
+        "include": { "mode": "include", "app_paths": [], "ip_ranges": [] }
+      }
+    }
+
+    mutate(st)
+    splitError = ""
+    // Proton writes this file with an indent of 4; match it so a diff after
+    // one of our writes shows the one section that changed and nothing else.
+    protonFile.setText(JSON.stringify(data, null, 4))
+    protonSettings = data
+    applySplitSettings()
+    return true
+  }
+
+  function toggleSplitTunnel() {
+    var on = !splitOn
+    writeSplit(function(st) { st["enabled"] = on })
+  }
+
+  function setSplitMode(mode) {
+    if (mode !== "exclude" && mode !== "include") return
+    if (mode === splitMode) return
+    writeSplit(function(st) { st["mode"] = mode })
+  }
+
+  // The panel hands back the full selection rather than one add or remove,
+  // which is what MultiSelect emits and what settings.json stores anyway.
+  //
+  // Paths are only ever accepted from the installed-app scan, so a path that
+  // isn't absolute never reaches the file. Anything else is dropped rather
+  // than repaired: this is Proton's file, and a guess about what someone
+  // meant is worse than ignoring it.
+  function setSplitApps(paths) {
+    var clean = []
+    var seen = ({})
+    var arr = (paths && typeof paths.length === "number") ? paths : []
+    for (var i = 0; i < arr.length; i++) {
+      var p = String(arr[i])
+      if (p.charAt(0) !== "/" || p.indexOf("\u0000") !== -1) continue
+      if (seen[p]) continue
+      seen[p] = true
+      clean.push(p)
+    }
+    var mode = splitMode
+    writeSplit(function(st) { st["config_by_mode"][mode]["app_paths"] = clean })
   }
 
   function toggleKillSwitch() { setConfig("kill-switch", killSwitchOn ? "off" : "standard") }
@@ -668,6 +838,24 @@ Item {
     printErrors: false
     onLoaded: root.applyState(text())
     onLoadFailed: root.applyState("{}")
+  }
+
+  // Proton's file, not ours. Watched rather than polled, because the CLI
+  // rewrites it on every `config set` and the panel would otherwise show a
+  // stale copy of a file that just changed underneath it.
+  FileView {
+    id: protonFile
+    path: root.protonSettingsPath
+    printErrors: false
+    watchChanges: true
+    atomicWrites: true
+    onLoaded: root.readProtonSettings(text())
+    onFileChanged: reload()
+    // No file yet, or no permission to read it. Either way there is nothing
+    // to edit and the panel says so instead of offering a switch that would
+    // have to create it.
+    onLoadFailed: { root.protonSettings = null; root.splitLoaded = true }
+    onSaveFailed: root.splitError = "Could not save Proton's settings"
   }
 
   Timer {

--- a/Service.qml
+++ b/Service.qml
@@ -523,6 +523,11 @@ Item {
   property var _ksReturn: null
 
   function toggleKillSwitch() {
+    // The mirror of the check in writeSplit(): Proton ignores split tunneling
+    // whenever the kill switch is on, so the two are mutually exclusive and
+    // each one locks the other. Here rather than on the row, because the
+    // keyboard cursor calls this directly and never sees `enabled`.
+    if (splitActive) return
     var value = killSwitchOn ? "off" : "standard"
     // Nothing to work around while the tunnel is down: one CLI call, as before.
     if (!connected && !linkActive) { setConfig("kill-switch", value); return }

--- a/Service.qml
+++ b/Service.qml
@@ -499,7 +499,52 @@ Item {
     writeSplit(function(st) { st["config_by_mode"][mode]["app_paths"] = clean })
   }
 
-  function toggleKillSwitch() { setConfig("kill-switch", killSwitchOn ? "off" : "standard") }
+  // Proton refuses a kill switch change while a tunnel is up: `config set
+  // kill-switch` answers "Disconnect before changing Kill Switch". A switch
+  // you can only use while disconnected isn't a switch, and Always On makes
+  // it worse, since disconnecting by hand is undone within a few seconds.
+  //
+  // So a click while connected does the whole thing: drop the tunnel, change
+  // the setting, put the tunnel back where it was. Always On is held off
+  // across it, otherwise it would reconnect into the middle and the change
+  // would fail exactly the way it does by hand.
+  property bool _ksCycle: false
+  property string _ksValue: ""
+  property var _ksReturn: null
+
+  function toggleKillSwitch() {
+    var value = killSwitchOn ? "off" : "standard"
+    // Nothing to work around while the tunnel is down: one CLI call, as before.
+    if (!connected && !linkActive) { setConfig("kill-switch", value); return }
+    if (_ksCycle || configPending !== "" || busy) return
+
+    _ksCycle = true
+    _ksValue = value
+    // Back to where we are now, rather than to whatever Fastest picks later.
+    _ksReturn = (recents.length > 0 && Array.isArray(recents[0].args)) ? recents[0] : null
+    // The row says "Turning off…" from the first click to the last step, the
+    // same words the one-call path uses. From the outside this is one change
+    // that takes longer, not three things happening to you.
+    configPending = "kill-switch"
+    configPendingValue = value
+    disconnect()
+  }
+
+  // Called when the tunnel is down and the setting has been written, whether
+  // or not it succeeded: leaving someone disconnected because their kill
+  // switch change failed would be the worse half of a bad trade.
+  function ksCycleFinish() {
+    _ksCycle = false
+    var target = _ksReturn
+    _ksReturn = null
+    // Starting a connect clears lastError, so a failed setting's message has
+    // to be carried across it. The tunnel coming back up is not evidence the
+    // change worked, and that is exactly when someone needs to be told.
+    var carried = lastError
+    if (target) connectTo(target.args, "Reconnecting to " + target.title + "…", target, false)
+    else connectTo([], "Reconnecting to fastest…", null, false)
+    if (carried !== "") lastError = carried
+  }
   // Full protection first; the CLI refuses ads/trackers on a free plan and
   // the retry below steps down to malware-only.
   function toggleNetShield() { setConfig("netshield", netShieldOn ? "off" : "malware-ads-trackers") }
@@ -787,6 +832,10 @@ Item {
   // a server that is full or gone can't stall this forever.
   function autoReconcile() {
     if (!autoReady) return
+    // The kill switch cycle drops the tunnel on purpose and puts it back
+    // itself. Always On stepping in here is what made this impossible to do
+    // by hand in the first place.
+    if (_ksCycle) return
     if (connected || linkActive || busy) return
     if (_autoNextMs > 0 && Date.now() < _autoNextMs) return
     var t = recents.length > 0 && Array.isArray(recents[0].args) ? recents[0] : null
@@ -1110,6 +1159,10 @@ Item {
         }
         root.lastError = Model.isPlanError(err) ? "Requires a Proton VPN Plus plan" : Model.elide(err || "Setting failed")
       }
+      // Last step of a kill switch change: whatever the CLI made of it, the
+      // tunnel goes back up. Before loadConfig(), so the re-read queues behind
+      // the connect instead of racing it.
+      if (root._ksCycle) root.ksCycleFinish()
       root.loadConfig()
     }
   }
@@ -1259,6 +1312,21 @@ Item {
         root.lastError = ""
         root.actionStatus = ""
       }
+      // Second step of a kill switch change: the tunnel is down, which is the
+      // only state the CLI will accept the setting in. A failed disconnect
+      // means the tunnel is still up, so there is nothing to try and the row
+      // goes back to what the CLI last reported.
+      if (root._ksCycle) {
+        if (exitCode !== 0) {
+          root._ksCycle = false
+          root._ksReturn = null
+          root.configPending = ""
+          root.configPendingValue = ""
+        } else {
+          root.applyConfig("kill-switch", root._ksValue)
+        }
+      }
+
       root.refreshAccount()
       delayedRefresh.restart()
     }

--- a/apps.py
+++ b/apps.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""List installed apps as split-tunneling candidates, for the panel's picker.
+
+Proton matches split-tunnelled processes by executable path, with a prefix
+test that also covers a matched process's children. So the panel needs a real
+path on disk for every app it offers, not a desktop-entry name, and it must
+never offer a path that would sweep in far more than the app asked for.
+
+Desktop entries are the only list of "apps a person recognises" the system
+keeps, so they are the source here. Each entry's Exec line is reduced to its
+program, resolved against PATH, and kept only if it is a file we can execute.
+
+Two kinds of entry are deliberately dropped:
+
+  * Flatpak and Snap launchers. Their Exec is the sandbox runner, so the path
+    on disk is /usr/bin/flatpak, shared by every Flatpak app. Excluding one
+    would silently exclude all of them. Matching a sandboxed app needs its
+    real binary, which the entry does not name.
+  * Anything that resolves to a shell, since a prefix match on /usr/bin/bash
+    would catch most of the session.
+  * Launcher stubs. Entries that go through hyprctl, uwsm, a terminal chooser
+    or Omarchy's web-app handlers name the dispatcher, not the app, and the
+    dispatcher has usually handed off to something else by the time the app
+    opens a socket. Offering them would promise an exclusion that never fires.
+
+Usage: apps.py            every candidate app, JSON, sorted by name
+Prints [{"value": <path>, "label": <name>, "description": <path>}, ...].
+"""
+import json
+import os
+import shlex
+import sys
+
+# Exec lines carry these placeholders for files and URLs; none survive here.
+FIELD_CODES = {"%f", "%F", "%u", "%U", "%d", "%D", "%n", "%N",
+               "%i", "%c", "%k", "%v", "%m"}
+
+# Runners whose path says nothing about which app is being launched.
+SANDBOX_RUNNERS = {"flatpak", "snap", "flatpak-spawn"}
+SHELLS = {"sh", "bash", "zsh", "fish", "dash", "ksh", "tcsh", "env", "sudo",
+          "pkexec", "gtk-launch", "xdg-open"}
+DISPATCHERS = {"hyprctl", "uwsm", "xdg-terminal-exec", "systemd-run", "dbus-launch"}
+DISPATCHER_PREFIXES = ("omarchy-launch-", "omarchy-webapp-handler-")
+
+
+def data_dirs():
+    """Every directory that can hold desktop entries, most specific first."""
+    home = os.path.expanduser("~")
+    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(home, ".local", "share")
+    dirs = [data_home]
+    raw = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+    dirs.extend(d for d in raw.split(":") if d)
+    return [os.path.join(d, "applications") for d in dirs]
+
+
+def parse_entry(path):
+    """Returns (name, exec_line) from a .desktop file, or None to skip it."""
+    name = None
+    exec_line = None
+    in_entry = False
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if line.startswith("["):
+                    # Only the first group describes the app itself; the
+                    # Desktop Action groups after it are separate launchers.
+                    if in_entry:
+                        break
+                    in_entry = line == "[Desktop Entry]"
+                    continue
+                if not in_entry or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                value = value.strip()
+                if key == "Type" and value != "Application":
+                    return None
+                if key in ("NoDisplay", "Hidden") and value.lower() == "true":
+                    return None
+                if key == "Name" and name is None:
+                    name = value
+                elif key == "Exec" and exec_line is None:
+                    exec_line = value
+    except OSError:
+        return None
+    if not name or not exec_line:
+        return None
+    return name, exec_line
+
+
+def program_of(exec_line):
+    """The program a desktop Exec line runs, or None when it is not usable."""
+    try:
+        parts = shlex.split(exec_line)
+    except ValueError:
+        return None
+    parts = [p for p in parts if p not in FIELD_CODES]
+    # Strip leading VAR=value assignments and an `env` wrapper around them.
+    while parts and (("=" in parts[0] and not parts[0].startswith("/"))
+                     or os.path.basename(parts[0]) == "env"):
+        parts.pop(0)
+    if not parts:
+        return None
+    program = parts[0]
+    base = os.path.basename(program)
+    if base in SANDBOX_RUNNERS or base in SHELLS or base in DISPATCHERS:
+        return None
+    if base.startswith(DISPATCHER_PREFIXES):
+        return None
+    return program
+
+
+def resolve(program):
+    """Absolute path to an executable file, or None."""
+    if program.startswith("/"):
+        candidate = program
+    else:
+        candidate = None
+        for directory in (os.environ.get("PATH") or "/usr/bin").split(":"):
+            if not directory:
+                continue
+            guess = os.path.join(directory, program)
+            if os.path.isfile(guess) and os.access(guess, os.X_OK):
+                candidate = guess
+                break
+    if not candidate:
+        return None
+    candidate = os.path.realpath(candidate)
+    if not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
+        return None
+    return candidate
+
+
+def collect():
+    by_path = {}
+    seen_files = set()
+    for directory in data_dirs():
+        try:
+            names = sorted(os.listdir(directory))
+        except OSError:
+            continue
+        for entry in names:
+            if not entry.endswith(".desktop") or entry in seen_files:
+                continue
+            # An entry in a more specific directory shadows the same file
+            # name later on, which is how a user override is meant to work.
+            seen_files.add(entry)
+            parsed = parse_entry(os.path.join(directory, entry))
+            if not parsed:
+                continue
+            name, exec_line = parsed
+            program = program_of(exec_line)
+            if not program:
+                continue
+            path = resolve(program)
+            if not path:
+                continue
+            # Several entries can share one binary; the shortest name is
+            # nearly always the app itself rather than a variant of it.
+            if path not in by_path or len(name) < len(by_path[path]):
+                by_path[path] = name
+    return by_path
+
+
+def main():
+    by_path = collect()
+    apps = [{"value": path, "label": name, "description": path}
+            for path, name in by_path.items()]
+    apps.sort(key=lambda a: (a["label"].lower(), a["value"]))
+    json.dump(apps, sys.stdout, separators=(",", ":"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1.

Protection gains a **Split tunneling** switch: pick apps that skip the VPN, or
flip it round so only the apps you pick use it. Getting there meant fixing the
Kill Switch, which could not be turned off from the panel at all, and four
places where a control described its stored value instead of what was actually
happening.

## Split tunneling

Turn it on and two rows appear: **Mode** (Exclude or Include) and an **Apps**
list you can search and tick. Proton keeps a separate app list per mode and so
does the panel, so switching modes doesn't discard the other one.

Proton has no CLI command for this. The capability is all on the machine, the
settings model, a D-Bus daemon and its eBPF socket tagging, but
`protonvpn config set` has eight subcommands and split tunneling isn't one of
them. Upstream's README lists it as a known gap.

So the widget edits `~/.config/Proton/VPN/settings.json` directly. That's the
first file this plugin writes that isn't its own, so every rule lives in one
function:

- read the file fresh, change only `features.split_tunneling`, hand every other
  key back exactly as found
- never create it. Missing or unparsable means Proton hasn't run here, and the
  row says "Sign in and connect once first"
- app paths only come from the widget's own scan, and anything that isn't an
  absolute path is dropped rather than repaired
- atomic writes, so an interrupted write can't leave half a settings file
- never write while `protonvpn config set` is running

Nothing pushes the file at Proton on its own, so the `protonvpn status` the
widget already runs is what applies a change to a live tunnel. With the tunnel
down it lands on the next connect either way.

`apps.py` turns desktop entries into real paths on disk, since Proton matches
by executable path. Flatpaks, Snaps, terminal choosers, `hyprctl`, `uwsm` and
web-app handlers are dropped: they all resolve to one shared launcher, so
picking one would pick all of them.

## The Kill Switch, which had to be fixed first

Proton refuses `config set kill-switch` while a tunnel is up, and Always On
undoes a manual disconnect within seconds. Between them, the Kill Switch could
not be turned off from the panel at all, and split tunneling only works with it
off, so the feature was unreachable.

A click while connected now does the whole thing: drop the tunnel, write the
setting, reconnect to the same server, with Always On held off in between. It
asks first in a dialog, because until the tunnel is back nothing is protected
and that's the user's call. Cancel is preselected. Disconnected, it is still
the single CLI call it always was, with no dialog.

Both failure paths leave you on the VPN rather than off it. A failed disconnect
abandons the change with the tunnel still up. A failed write reconnects anyway,
and carries the error across the connect that would otherwise clear it.

## The two switches now lock each other

They are mutually exclusive, since Proton ignores split tunneling whenever the
Kill Switch is on. Each row locks the other and names the one to turn off, the
same sentence in both directions. The lock lives in the service rather than on
the rows, because the keyboard cursor calls these functions directly and never
sees `enabled`. The Kill Switch nudge is hidden while split tunneling is live
rather than offering a button that cannot work.

Neither switch ever turns itself on. Turning the Kill Switch off writes split
tunneling's flag off first, so the file agrees with what the panel has been
showing, with both app lists left alone.

## What is deliberately not here

**IP ranges.** The settings file has the field, but nothing on Linux reads it:
the daemon builds its match list from `app_paths` alone and no connection
backend touches it. A UI for it would write a setting that does nothing.

**IPv6.** Proton attaches its eBPF program to `CGROUP_INET_SOCK_CREATE` with no
IPv6 equivalent, so an excluded app still uses the tunnel for anything it sends
over IPv6. Not fixable from here, documented in the README, and the reason a
test with `curl` and no `-4` looks like a broken exclusion.

**Individually selectable web apps.** Omarchy's web apps all run as the same
browser binary, so there is no path that names one of them. Tick the browser
instead, which covers them all.

## Verification

Proven end to end on a real connection before any code was written: a process
in the exclude list left through the ISP while an identical process not in the
list stayed on the tunnel, same request, same moment. Then proven again through
the finished panel, in both modes, with Ghostty and foot side by side on
different exit IPs.

A harness drives the real Service and the real Panel against a stateful CLI
stub that reproduces Proton's rules, plus a copy of the real settings file:

- the row's text in every state, including loading, blocked, and no file
- per-mode app lists survive a mode switch, in both directions
- relative paths and duplicates dropped
- missing file and corrupt file: nothing created, nothing overwritten
- with the Kill Switch on, nine attempted changes wrote nothing
- diffed against a real settings file, the only change is the app list
- Kill Switch both directions while connected and while disconnected, plus a
  failed disconnect and a failed write
- the dialog: opens on a connected click, Cancel changes nothing, Confirm
  carries through, no dialog when disconnected or when locked

## Commits

Four of the seven are bugs found by clicking through it rather than reading it,
all the same shape: a control describing its stored value instead of its actual
effect. Worth watching for in the rest of this panel.