### PR TITLE
Notifications: OmaProton mark in the theme accent, fixes the checkerboard icon (#21)

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -84,6 +84,17 @@ function parseStatus(raw) {
   }
 }
 
+// settings.json `protocol` -> a label for the panel and notifications.
+function protocolLabel(raw) {
+  var p = String(raw || "").trim().toLowerCase()
+  if (p === "") return ""
+  if (p === "wireguard") return "WireGuard"
+  if (p === "openvpn-udp" || p === "openvpn_udp") return "OpenVPN UDP"
+  if (p === "openvpn-tcp" || p === "openvpn_tcp") return "OpenVPN TCP"
+  if (p.indexOf("openvpn") === 0) return "OpenVPN"
+  return p.charAt(0).toUpperCase() + p.slice(1)
+}
+
 // `protonvpn info` -> "Account: 'user@example.com'", or "Account: 'None'"
 // while signed out.
 function parseAccount(raw) {

--- a/README.md
+++ b/README.md
@@ -458,9 +458,9 @@ signing out also disconnects.
 
 ### Notifications
 
-If the VPN drops unexpectedly you get a desktop notification, "Proton VPN
-disconnected, You're no longer protected." Connecting shows "Protected" with
-the server. Turn both off in the widget's settings if you'd rather not.
+If the VPN drops unexpectedly you get a desktop notification, "VPN
+Disconnected, You're no longer protected." Connecting shows "VPN Connected"
+with the server and the protocol. Turn both off in the widget's settings if you'd rather not.
 
 ## Settings
 
@@ -468,7 +468,7 @@ Configurable from Omarchy's widget settings:
 
 | Setting | Default | What it controls |
 | --- | --- | --- |
-| Desktop notifications | On | "Protected" on connect; "disconnected" if the tunnel drops unexpectedly. |
+| Desktop notifications | On | "VPN Connected" with the server and protocol on connect; "VPN Disconnected" if the tunnel drops unexpectedly. |
 | Status refresh interval | 30 s | How often `protonvpn status` runs for the detail rows while the panel is closed. Open panel: every 5 s. |
 | Link watch interval | 4 s | How often `nmcli` is polled for the bar icon. |
 
@@ -553,8 +553,8 @@ when its own cache has expired, server loads every ~15 minutes, the full list
 every ~3 hours, and only while connected. The widget's polling doesn't add API
 traffic beyond what the client already does on its own schedule.
 
-**Notifications** go through `notify-send` and contain only the connection
-state and server name.
+**Notifications** are sent straight to the desktop notification service over
+D-Bus and contain only the connection state and server name.
 
 **On screen.** Your Proton account email is shown only under Protection →
 Account, not in the panel's default view, but if you screenshot or

--- a/Service.qml
+++ b/Service.qml
@@ -764,10 +764,39 @@ Item {
     uptimeSec = _linkUpMs > 0 ? Math.floor((now - _linkUpMs) / 1000) : 0
   }
 
+  // The plugin's own mark for the toast, written to the state dir in the
+  // theme's accent colour so it wears every Omarchy theme like the widget
+  // does, and rewritten whenever the theme changes. A themed-icon name was
+  // the wrong tool here: most icon themes don't carry `network-vpn`, and
+  // the shell drew Qt's missing-texture checkerboard in its place (#21).
+  readonly property string notificationIconPath: stateDir + "/notification-icon.svg"
+  readonly property string protonMarkPath: "m10.176 20.058.858-1.28 6.513-9.838c.57-.86.026-2.014-1.005-2.131L.378 4.95l8.373 15.055a.84.84 0 0 0 1.424.052h.001zM23.586 7.14l-9.662 14.61c-1.036 1.567-3.38 1.478-4.293-.162l-.093-.168c.3-.01.594-.086.855-.235a1.85 1.85 0 0 0 .612-.57l.86-1.28 6.516-9.844c.46-.694.525-1.56.173-2.314a2.375 2.375 0 0 0-1.899-1.364L.493 3.956l-.476-.054C-.163 2.392 1.101.95 2.784 1.143l18.991 2.16c1.856.21 2.835 2.289 1.812 3.838z"
+
+  function writeNotificationIcon() {
+    // Qt prints an opaque colour as #rrggbb and a translucent one as
+    // #aarrggbb; SVG wants the former, so drop the alpha if present.
+    var hex = String(Color.accent)
+    if (hex.length === 9) hex = "#" + hex.slice(3)
+    notificationIconFile.setText('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">'
+                                 + '<path fill="' + hex + '" d="' + protonMarkPath + '"/></svg>\n')
+  }
+
   function notify(summary, body, urgency) {
     if (!notificationsOn) return
-    Quickshell.execDetached(["notify-send", "-a", "Proton VPN", "-i", "network-vpn",
-                             "-u", urgency || "normal", summary, body || ""])
+    // Call org.freedesktop.Notifications.Notify directly instead of going
+    // through notify-send or the omarchy-notification-send wrapper: one
+    // process, no argv reparsing of the summary/body, and the omarchy-glyph
+    // hint gives the shell a Nerd Font shield-lock to draw if the SVG isn't
+    // there yet (first launch) or fails to load. Signature: app_name, replaces_id, app_icon, summary,
+    // body, actions, hints, expire_timeout.
+    var level = urgency === "critical" ? "2" : (urgency === "low" ? "0" : "1")
+    Quickshell.execDetached(["busctl", "--user", "--", "call",
+                             "org.freedesktop.Notifications", "/org/freedesktop/Notifications",
+                             "org.freedesktop.Notifications", "Notify", "susssasa{sv}i",
+                             "OmaProton VPN", "0", notificationIconPath, summary, body || "",
+                             "0",
+                             "2", "urgency", "y", level, "omarchy-glyph", "s", "\udb82\udd9d",
+                             "-1"])
   }
 
   function applyStatus(raw) {
@@ -902,7 +931,13 @@ Item {
     // Owner-only, and fixed up on existing installs too: the file holds where
     // you've been connecting, which is nobody else's business on a shared box.
     Quickshell.execDetached(["install", "-d", "-m", "700", stateDir])
+    writeNotificationIcon()
     refresh()
+  }
+
+  Connections {
+    target: Color
+    function onAccentChanged() { root.writeNotificationIcon() }
   }
 
   onPanelOpenChanged: if (panelOpen) {
@@ -926,6 +961,13 @@ Item {
     running: root.panelOpen && root.linkActive && root.linkDevice !== ""
     triggeredOnStart: true
     onTriggered: root.trafficSample()
+  }
+
+  FileView {
+    id: notificationIconFile
+    path: root.notificationIconPath
+    printErrors: false
+    atomicWrites: true
   }
 
   FileView {
@@ -1109,7 +1151,7 @@ Item {
       // of a connect the person just asked for.
       if (was && !link.active) {
         if (!root._expectDown && !actionProcess.running && !connectProcess.running)
-          root.notify("Proton VPN disconnected", "You're no longer protected.", "critical")
+          root.notify("VPN Disconnected \udb83\udfc6", "You're no longer protected.", "critical")
         root._expectDown = false
       }
       root.reconcile()
@@ -1328,7 +1370,12 @@ Item {
           }
         }
         root.recordRecent(target)
-        root.notify("Protected", line, "normal")
+        // "Connected to NL#42 in Amsterdam, Netherlands." -> the server, plus
+        // the protocol the CLI is configured for, since its confirmation
+        // line never names it and `protonvpn status` hasn't run yet.
+        var where = line.replace(/^connected to\s+/i, "").replace(/\.\s*$/, "")
+        var proto = Model.protocolLabel(root.protonSettings ? root.protonSettings["protocol"] : "")
+        root.notify("VPN Connected \udb80\udf3e", [where, proto].filter(function(v) { return v !== "" }).join(" · "), "normal")
         root.loadCities(true)
       }
       // Look at the link now rather than waiting up to watchIntervalSec, so


### PR DESCRIPTION
Fixes #21

Reported and diagnosed by @CJKaufman, who traced the checkerboard to `-i network-vpn` failing to resolve against the icon theme. Thanks CJ.

## Problem
The connect/disconnect toasts went through `notify-send -i network-vpn`. Most icon themes (Yaru, Adwaita) only ship the `-symbolic` variant, so omarchy-shell drew Qt's purple/black missing-texture placeholder in the icon slot.

## What changed
**Icon.** The service writes the Proton mark as an SVG to `~/.local/state/omarchy-protonvpn/notification-icon.svg`, filled with the theme's `Color.accent`, and rewrites it whenever the accent changes. The toast wears the same theme as the widget.

**Delivery.** `notify()` calls `org.freedesktop.Notifications.Notify` directly over `busctl`: a single process, no `notify-send` argv reparsing of the summary or body, and an `omarchy-glyph` shield fallback so the first toast on a fresh install still has an icon if the SVG hasn't landed yet.

**Wording.**
- `VPN Connected 󰌾` with the server and protocol in the body, e.g. `US-TX#40 in Dallas, United States · WireGuard`. Server comes from the CLI's confirmation line, protocol from Proton's `settings.json` via the new `Model.protocolLabel`.
- `VPN Disconnected 󰿆` / `You're no longer protected.` when the tunnel drops unexpectedly.
- README notification section updated to match.

## Files
- `Service.qml`: `notificationIconPath`, `writeNotificationIcon()`, `notificationIconFile` FileView, accent-change hook, `notify()` rewrite, new strings.
- `Model.js`: `protocolLabel()`.
- `README.md`: wording.

## Verified
- `Service.qml` loads Ready in a standalone quickshell harness and writes the SVG with the accent colour.
- Both toasts rendered live on Omarchy 4.0.0.alpha through the exact D-Bus payload the plugin sends.
- Installed the branch in the live shell and reproduced the real disconnect path (Always On drop): icon and text render as above.

## After merging
The local plugin checkout is on `fix/notification-icon`; switch it back with `git checkout staging && git pull` in `~/.config/omarchy/plugins/io.github.grichard99.omaproton-vpn`.