### PR TITLE
Map: draw the Secure Core route from the entry country to the exit city

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -84,6 +84,16 @@ function parseStatus(raw) {
   }
 }
 
+// Secure Core servers are named for both hops: "CH-US#3" enters Switzerland
+// and exits US server 3. Show that as a route, "CH → US#3". Only CH, IS and
+// SE are entry countries, which keeps regional names like "US-TX#40" as-is.
+function routeLabel(name) {
+  var n = String(name || "").trim()
+  var m = n.match(/^(CH|IS|SE)-([A-Z]{2}(?:-[A-Z]{2,3})?)#(\d+)$/i)
+  if (!m) return n
+  return m[1].toUpperCase() + " → " + m[2].toUpperCase() + "#" + m[3]
+}
+
 // settings.json `protocol` -> a label for the panel and notifications.
 function protocolLabel(raw) {
   var p = String(raw || "").trim().toLowerCase()

--- a/Panel.qml
+++ b/Panel.qml
@@ -117,7 +117,7 @@ Panel {
     if (!vpn.installed) return vpn.installing ? "Installing…" : "Not installed"
     if (vpn.busy && vpn.pendingLabel !== "") return vpn.pendingLabel
     if (vpn.connected) {
-      var server = vpn.displayServer
+      var server = Model.routeLabel(vpn.displayServer)
       return server !== "" ? server : "Protected"
     }
     if (!vpn.accountProbed) return "Checking…"

--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ The map doesn't show *your* location or draw a line to the server, the way the
 Proton app does. Finding your location would take a geo-IP lookup, which this
 plugin promises never to make. Lighting up the exit city is the honest version.
 
+On a Secure Core connection the map does draw the route: a dashed arc from the
+entry country (Switzerland, Iceland or Sweden, ringed) to the city you exit
+from, just like the Proton app. Both ends are Proton servers named in the
+server cache, so no lookup about you is involved.
+
 ### The power switch
 
 The switch at the top of the panel is the same toggle as right-click. When off,

--- a/WorldMap.qml
+++ b/WorldMap.qml
@@ -13,7 +13,9 @@ import "World.js" as World
 //
 // The map deliberately does not draw *your* location or a line to the server:
 // finding it would take a geo-IP lookup, which this plugin promises never to
-// make. Lighting the exit city is the honest version.
+// make. Lighting the exit city is the honest version. A Secure Core route is
+// different: both ends are Proton servers named in the server list, so the
+// map draws the hop from the entry country to the exit city.
 Item {
   id: root
 
@@ -24,6 +26,8 @@ Item {
   property color foreground: Color.foreground
   property string fontFamily: Style.font.family
   readonly property color dim: Qt.darker(foreground, 1.55)
+  // {code, city, lat, lon} for the Secure Core entry country, or null.
+  readonly property var entry: connected && current && current.entry && current.entry.lat !== undefined && current.entry.lat !== null ? current.entry : null
 
   signal cityClicked(var city)
 
@@ -63,6 +67,50 @@ Item {
       fillRule: ShapePath.WindingFill
       PathSvg { path: World.PATH }
     }
+  }
+
+  // Secure Core route: a dashed arc from the entry country to the exit city,
+  // bowed a little so it reads as a route rather than a ruler line.
+  Shape {
+    visible: root.entry !== null
+    anchors.fill: parent
+    antialiasing: true
+    preferredRendererType: Shape.CurveRenderer
+    z: 2
+
+    ShapePath {
+      strokeColor: root.foreground
+      strokeWidth: 1.2
+      fillColor: "transparent"
+      capStyle: ShapePath.RoundCap
+      strokeStyle: ShapePath.DashLine
+      dashPattern: [3, 3]
+      startX: root.entry ? root.px(root.entry) : 0
+      startY: root.entry ? root.py(root.entry) : 0
+
+      PathQuad {
+        readonly property real x0: root.entry ? root.px(root.entry) : 0
+        readonly property real y0: root.entry ? root.py(root.entry) : 0
+        readonly property real x1: root.current ? root.px(root.current) : 0
+        readonly property real y1: root.current ? root.py(root.current) : 0
+        x: x1
+        y: y1
+        controlX: (x0 + x1) / 2 - (y1 - y0) * 0.25
+        controlY: (y0 + y1) / 2 - Math.abs(x1 - x0) * 0.18
+      }
+    }
+  }
+
+  // Secure Core entry country
+  Rectangle {
+    visible: root.entry !== null
+    width: 6; height: 6; radius: 3
+    color: "transparent"
+    border.color: root.foreground
+    border.width: 1.5
+    x: root.entry ? root.px(root.entry) - width / 2 : 0
+    y: root.entry ? root.py(root.entry) - height / 2 : 0
+    z: 3
   }
 
   // Pulse behind the connected city

--- a/servers.py
+++ b/servers.py
@@ -115,20 +115,48 @@ def all_cities(data):
     return rows
 
 
+def country_place(data, code):
+    """Where a country is, for the map: the location of its first regular
+    server. Secure Core entry countries (CH, IS, SE) each have one city."""
+    for s in data.get("LogicalServers") or []:
+        if (s.get("ExitCountry") or "").upper() != code:
+            continue
+        if (s.get("Features") or 0) & SECURE_CORE:
+            continue
+        loc = s.get("Location") or {}
+        if loc.get("Lat") is None or loc.get("Long") is None:
+            continue
+        return {
+            "code": code,
+            "city": (s.get("City") or "").strip(),
+            "lat": loc.get("Lat"),
+            "lon": loc.get("Long"),
+        }
+    return None
+
+
 def locate(data, name):
-    """Where one server is. Used to light up the connected city on the map."""
+    """Where one server is. Used to light up the connected city on the map.
+    A Secure Core server (CH-US#3: enters Switzerland, exits New York) also
+    carries its entry hop so the map can draw the route."""
     want = name.strip().upper()
     for s in data.get("LogicalServers") or []:
         if (s.get("Name") or "").upper() != want:
             continue
         loc = s.get("Location") or {}
-        return {
+        place = {
             "name": s.get("Name") or "",
             "code": (s.get("ExitCountry") or "").upper(),
             "city": (s.get("City") or "").strip(),
             "lat": loc.get("Lat"),
             "lon": loc.get("Long"),
         }
+        entry_code = (s.get("EntryCountry") or "").upper()
+        if (s.get("Features") or 0) & SECURE_CORE and entry_code and entry_code != place["code"]:
+            entry = country_place(data, entry_code)
+            if entry:
+                place["entry"] = entry
+        return place
     return {}
 
 


### PR DESCRIPTION
## What
On a Secure Core connection the map now draws the route like the Proton app: a dashed arc from the entry country (Switzerland, Iceland or Sweden, ringed) to the exit city, which keeps its pulse. Regular connections look exactly as before.

## How
- `servers.py --locate`: a Secure Core server (`Features & 1`, e.g. `CH-US#3`) also returns an `entry` hop `{code, city, lat, lon}` resolved from the entry country's regular servers via the new `country_place()`. Other servers return the same shape as today.
- `Service.qml`: no change; `currentPlace` already passes the whole object through to the map.
- `WorldMap.qml`: `entry` property derived from `current.entry`; a `Shape` with a `PathQuad` dashed arc and a ringed entry dot, both hidden unless connected on Secure Core.
- README: map section notes the route and why it doesn't contradict the no-lookup promise (both ends are Proton servers named in the cache).

## Verified
- `python3 servers.py --locate CH-US#3` returns the entry hop for Zurich; `US-NY#1` returns no `entry`.
- `WorldMap.qml` rendered in a quickshell harness with the real city list and a `CH-US#3` current: arc from Zurich to New York, ring on Zurich, pulse on New York.

## Header
The hero meta shows a Secure Core connection as its route: `CH → US#3` (entry country, then exit server) via `Model.routeLabel`. Regional names like `US-TX#40` are left alone since only CH, IS and SE are entry countries. The Server detail row keeps the exact CLI name.

## Making it obvious
- Header meta on a Secure Core connection: `󰦝 SECURE CORE · CH → US#3` (shield-lock glyph, feature, route).
- The Secure Core quick-connect row shows an `ACTIVE` tag instead of `PLUS` while connected through it.
- `Model.isSecureCore(name)` backs both; regional names such as `US-TX#40` are not matched.

## P2P
- `--locate` returns `p2p` (feature bit 4). The **P2P** quick-connect row shows `ACTIVE` while the server you're on permits P2P.
- The header reads `󰒗 P2P · US-TX#561` only when you got there via the P2P row (`p2pRequested`), since ~85% of Proton servers permit P2P and a badge on every connection would be noise.