### PR TITLE
Suppress desktop notifications while the panel is open

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Configurable from Omarchy's widget settings:
 
 | Setting | Default | What it controls |
 | --- | --- | --- |
-| Desktop notifications | On | "VPN Connected" with the server and protocol on connect; "VPN Disconnected" if the tunnel drops unexpectedly. |
+| Desktop notifications | On | "VPN Connected" with the server and protocol on connect; "VPN Disconnected" if the tunnel drops unexpectedly. Not shown while the panel is open, since the panel already says so. |
 | Status refresh interval | 30 s | How often `protonvpn status` runs for the detail rows while the panel is closed. Open panel: every 5 s. |
 | Link watch interval | 4 s | How often `nmcli` is polled for the bar icon. |
 

--- a/Service.qml
+++ b/Service.qml
@@ -783,6 +783,9 @@ Item {
 
   function notify(summary, body, urgency) {
     if (!notificationsOn) return
+    // The panel already shows the state change in its header and map, so a
+    // toast on top of it is noise. Only notify when the panel isn't open.
+    if (panelOpen) return
     // Call org.freedesktop.Notifications.Notify directly instead of going
     // through notify-send or the omarchy-notification-send wrapper: one
     // process, no argv reparsing of the summary/body, and the omarchy-glyph


### PR DESCRIPTION
## What
`notify()` returns early when `panelOpen` is true. The panel's header and map already show the connect or the unexpected drop, so a toast on top of it is redundant. Closed-panel behaviour is unchanged.

Standard desktop practice (GNOME, KDE, the Proton app, Tailscale): don't notify about state the app's own window is already showing.

## Not a regression
`notify()` never checked `panelOpen`; 1.3.2 popped these too. #22 made the toast visible enough to notice.

## Files
- `Service.qml`: one guard in `notify()`.
- `README.md`: settings table note.