### PR TITLE
Port forwarding: switch it on, see the forwarded port, copy it with one click

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -53,7 +53,7 @@ Panel {
   // asked first.
   readonly property string vpnKs: vpn.config["kill-switch"] || ""
   readonly property alias killSwitchDialog: killSwitchConfirm
-  readonly property int protectionCount: splitDetailVisible ? 7 : 5
+  readonly property int protectionCount: splitDetailVisible ? 8 : 6
   readonly property int signOutIndex: protectionCount - 1
 
   // App paths Proton's file already holds that the scan no longer finds, kept
@@ -293,10 +293,11 @@ Panel {
     else if (focusSection === "protection") {
       if (protectionIndex === 0) requestKillSwitch()
       else if (protectionIndex === 1) vpn.toggleNetShield()
-      else if (protectionIndex === 2) vpn.toggleAutoConnect()
-      else if (protectionIndex === 3) vpn.toggleSplitTunnel()
-      else if (splitDetailVisible && protectionIndex === 4) splitModeRow.toggle()
-      else if (splitDetailVisible && protectionIndex === 5) splitAppsRow.toggle()
+      else if (protectionIndex === 2) vpn.togglePortForwarding()
+      else if (protectionIndex === 3) vpn.toggleAutoConnect()
+      else if (protectionIndex === 4) vpn.toggleSplitTunnel()
+      else if (splitDetailVisible && protectionIndex === 5) splitModeRow.toggle()
+      else if (splitDetailVisible && protectionIndex === 6) splitAppsRow.toggle()
       else requestSignOut()
     }
     else if (focusSection === "recents") { vpn.connectRecent(recentIndex); showConnection() }
@@ -495,6 +496,8 @@ Panel {
         splitTunneling: vpn.splitOn ? vpn.splitMode : "off",
         splitApps: vpn.splitApps.length,
         netshield: vpn.config["netshield"] || "",
+        portForwarding: vpn.config["port-forwarding"] || "",
+        forwardedPort: vpn.forwardedPort,
         countries: vpn.countries.length,
         recents: vpn.recents.length,
         cities: vpn.cities.length,
@@ -814,6 +817,13 @@ Panel {
 
             InfoPair { label: "Server"; value: vpn.displayServer }
             InfoPair { visible: vpn.location !== ""; label: "Location"; value: vpn.location }
+            CopyPair {
+              visible: vpn.forwardedPort !== ""
+              label: "Forwarded port"
+              value: vpn.forwardedPort
+              copied: root.portCopied
+              onCopy: root.copyPort()
+            }
 
             Repeater {
               model: vpn.fields
@@ -1025,7 +1035,28 @@ Panel {
                 onClicked: { root.clearHighlight(); vpn.toggleNetShield() }
               }
 
-              // Widget-owned, unlike the two above: the CLI has no setting for
+              Toggle {
+                width: parent.width
+                label: "Port forwarding"
+                description: {
+                  var applying = vpn.configPendingLabel("port-forwarding")
+                  if (applying !== "") return applying
+                  if (!vpn.configLoaded) return "Loading…"
+                  if (!vpn.portForwardingOn) return "For torrent clients, on P2P servers"
+                  if (vpn.forwardedPort !== "") return "Port " + vpn.forwardedPort + " on this server"
+                  if (vpn.connected) return "Needs a P2P server: Quick connect → P2P"
+                  return "Connect to a P2P server to get a port"
+                }
+                checked: vpn.portForwardingOn
+                enabled: vpn.configLoaded && vpn.configPending === ""
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 2) }
+                onClicked: { root.clearHighlight(); vpn.togglePortForwarding() }
+              }
+
+              // Widget-owned, unlike the three above: the CLI has no setting for
               // this, so it lives in the widget's own state file.
               Toggle {
                 width: parent.width
@@ -1033,10 +1064,10 @@ Panel {
                 description: "Reconnects on boot and interruptions"
                 checked: vpn.autoConnect
                 enabled: !vpn.busy
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 2) }
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 3) }
                 onClicked: { root.clearHighlight(); vpn.toggleAutoConnect() }
               }
 
@@ -1049,10 +1080,10 @@ Panel {
                 description: vpn.splitDescription()
                 checked: vpn.splitActive
                 enabled: vpn.splitAvailable && !vpn.splitBlocked
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 4
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 3) }
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 4) }
                 onClicked: { root.clearHighlight(); vpn.toggleSplitTunnel() }
               }
 
@@ -1066,10 +1097,10 @@ Panel {
                   { value: "exclude", label: "Exclude: chosen apps skip the VPN" },
                   { value: "include", label: "Include: only chosen apps use the VPN" }
                 ]
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 4
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 5
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 4) }
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 5) }
                 onChanged: function(value) { vpn.setSplitMode(value) }
               }
 
@@ -1088,10 +1119,10 @@ Panel {
                 placeholderText: "Search apps..."
                 emptyText: "No apps found"
                 noSelectionText: "None chosen"
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 5
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 6
                 foreground: root.foreground
                 fontFamily: root.fontFamily
-                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 5) }
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 6) }
                 onChanged: function(values) { vpn.setSplitApps(values) }
               }
 
@@ -1620,6 +1651,46 @@ Panel {
         font.pixelSize: Style.font.bodySmall
         Layout.alignment: Qt.AlignVCenter
       }
+    }
+  }
+
+  // A 2 s "Copied" flash on the forwarded port row.
+  property bool portCopied: false
+  Timer { id: portCopiedTimer; interval: 2000; onTriggered: root.portCopied = false }
+  function copyPort() {
+    vpn.copyForwardedPort()
+    portCopied = true
+    portCopiedTimer.restart()
+  }
+
+  // An InfoPair you click to copy the value. The value carries a copy glyph
+  // and flips to "Copied" for a moment, so a torrent client is one paste away.
+  component CopyPair: Row {
+    id: copyPair
+    property string label: ""
+    property string value: ""
+    property bool copied: false
+    signal copy()
+
+    width: parent.width
+    spacing: Style.space(8)
+
+    InfoLabel { text: copyPair.label }
+    Item {
+      width: Math.max(0, parent.width - parent.children[0].implicitWidth - parent.children[2].implicitWidth - parent.spacing * 2)
+      height: 1
+    }
+    InfoValue {
+      text: copyPair.copied ? "Copied" : copyPair.value + "  󰆏"
+      opacity: copyArea.containsMouse || copyPair.copied ? 1.0 : 0.85
+    }
+
+    MouseArea {
+      id: copyArea
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onClicked: copyPair.copy()
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -1665,7 +1665,7 @@ Panel {
 
   // An InfoPair you click to copy the value. The value carries a copy glyph
   // and flips to "Copied" for a moment, so a torrent client is one paste away.
-  component CopyPair: Row {
+  component CopyPair: Item {
     id: copyPair
     property string label: ""
     property string value: ""
@@ -1673,16 +1673,25 @@ Panel {
     signal copy()
 
     width: parent.width
-    spacing: Style.space(8)
+    implicitHeight: copyRow.implicitHeight
+    height: implicitHeight
 
-    InfoLabel { text: copyPair.label }
-    Item {
-      width: Math.max(0, parent.width - parent.children[0].implicitWidth - parent.children[2].implicitWidth - parent.spacing * 2)
-      height: 1
-    }
-    InfoValue {
-      text: copyPair.copied ? "Copied" : copyPair.value + "  󰆏"
-      opacity: copyArea.containsMouse || copyPair.copied ? 1.0 : 0.85
+    // A Row can't hold an anchored MouseArea, so the row and the click
+    // target are siblings under this Item.
+    Row {
+      id: copyRow
+      width: parent.width
+      spacing: Style.space(8)
+
+      InfoLabel { text: copyPair.label }
+      Item {
+        width: Math.max(0, parent.width - parent.children[0].implicitWidth - parent.children[2].implicitWidth - parent.spacing * 2)
+        height: 1
+      }
+      InfoValue {
+        text: copyPair.copied ? "Copied" : copyPair.value + "  󰆏"
+        opacity: copyArea.containsMouse || copyPair.copied ? 1.0 : 0.85
+      }
     }
 
     MouseArea {

--- a/Panel.qml
+++ b/Panel.qml
@@ -293,8 +293,8 @@ Panel {
     else if (focusSection === "protection") {
       if (protectionIndex === 0) requestKillSwitch()
       else if (protectionIndex === 1) vpn.toggleNetShield()
-      else if (protectionIndex === 2) vpn.togglePortForwarding()
-      else if (protectionIndex === 3) vpn.toggleAutoConnect()
+      else if (protectionIndex === 2) vpn.toggleAutoConnect()
+      else if (protectionIndex === 3) requestPortForwarding()
       else if (protectionIndex === 4) vpn.toggleSplitTunnel()
       else if (splitDetailVisible && protectionIndex === 5) splitModeRow.toggle()
       else if (splitDetailVisible && protectionIndex === 6) splitAppsRow.toggle()
@@ -340,6 +340,18 @@ Panel {
     focusSection = "header"
     if (panelFlick) panelFlick.contentY = 0
   }
+
+  // Turning port forwarding on opens an inbound door; that deserves a
+  // sentence and a click. Turning it off just closes it.
+  function requestPortForwarding() {
+    if (vpn.portForwardingOn) { vpn.togglePortForwarding(); return }
+    portForwardConfirm.selectedIndex = 0
+    portForwardConfirm.opened = true
+  }
+
+  // Whichever dimmed dialog is up owns the keyboard.
+  readonly property var openDialog: killSwitchConfirm.opened ? killSwitchConfirm
+                                   : (portForwardConfirm.opened ? portForwardConfirm : null)
 
   // Disconnected there is nothing to interrupt, so the change just happens.
   // Connected, it costs a reconnect, and that is what the dialog is for.
@@ -566,24 +578,24 @@ Panel {
       onMoveRequested: function(dx, dy) {
         // A dialog with the screen dimmed behind it owns the keyboard, or the
         // cursor would be moving around underneath it unseen.
-        if (killSwitchConfirm.opened) {
-          killSwitchConfirm.selectedIndex = killSwitchConfirm.selectedIndex === 0 ? 1 : 0
+        if (root.openDialog) {
+          root.openDialog.selectedIndex = root.openDialog.selectedIndex === 0 ? 1 : 0
           return
         }
         if (!root.cursorActive) { root.cursorActive = true; return }
         root.moveCursor(dx, dy)
       }
       onActivateRequested: {
-        if (killSwitchConfirm.opened) {
-          if (killSwitchConfirm.selectedIndex === 0) killSwitchConfirm.canceled()
-          else killSwitchConfirm.confirmed()
+        if (root.openDialog) {
+          if (root.openDialog.selectedIndex === 0) root.openDialog.canceled()
+          else root.openDialog.confirmed()
           return
         }
         if (root.cursorActive) root.activateCursor()
       }
       // Inside a drill, escape backs out one level before it closes the panel.
       onCloseRequested: {
-        if (killSwitchConfirm.opened) { killSwitchConfirm.canceled(); return }
+        if (root.openDialog) { root.openDialog.canceled(); return }
         root.drilled ? root.drillOut() : root.close()
       }
       onTabRequested: function(direction) { root.switchPanel(direction) }
@@ -628,6 +640,21 @@ Panel {
         fontFamily: root.fontFamily
         onCanceled: opened = false
         onConfirmed: { opened = false; vpn.toggleKillSwitch() }
+      }
+
+      ConfirmDialog {
+        id: portForwardConfirm
+        anchors.fill: parent
+        z: 100
+        message: "Port forwarding opens an inbound port on your VPN address and sends "
+          + "whatever arrives on it to this computer. It's for torrent clients and only "
+          + "works on P2P servers. Turn it off again when you're done."
+        cancelText: "Cancel"
+        confirmText: "Turn on"
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        onCanceled: opened = false
+        onConfirmed: { opened = false; vpn.togglePortForwarding() }
       }
 
       Flickable {
@@ -1035,6 +1062,21 @@ Panel {
                 onClicked: { root.clearHighlight(); vpn.toggleNetShield() }
               }
 
+              // Widget-owned, unlike the two above: the CLI has no setting for
+              // this, so it lives in the widget's own state file.
+              Toggle {
+                width: parent.width
+                label: "Always On"
+                description: "Reconnects on boot and interruptions"
+                checked: vpn.autoConnect
+                enabled: !vpn.busy
+                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 2) }
+                onClicked: { root.clearHighlight(); vpn.toggleAutoConnect() }
+              }
+
               Toggle {
                 width: parent.width
                 label: "Port forwarding"
@@ -1049,27 +1091,13 @@ Panel {
                 }
                 checked: vpn.portForwardingOn
                 enabled: vpn.configLoaded && vpn.configPending === ""
-                hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 2
-                foreground: root.foreground
-                fontFamily: root.fontFamily
-                onHovered: function(on) { if (on) root.setCursorFromHover("protection", 2) }
-                onClicked: { root.clearHighlight(); vpn.togglePortForwarding() }
-              }
-
-              // Widget-owned, unlike the three above: the CLI has no setting for
-              // this, so it lives in the widget's own state file.
-              Toggle {
-                width: parent.width
-                label: "Always On"
-                description: "Reconnects on boot and interruptions"
-                checked: vpn.autoConnect
-                enabled: !vpn.busy
                 hasCursor: root.cursorActive && root.focusSection === "protection" && root.protectionIndex === 3
                 foreground: root.foreground
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursorFromHover("protection", 3) }
-                onClicked: { root.clearHighlight(); vpn.toggleAutoConnect() }
+                onClicked: { root.clearHighlight(); root.requestPortForwarding() }
               }
+
 
               // Proton skips split tunneling entirely while the kill switch
               // is on, so the row says that instead of offering a switch that

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 Under Quick Connect sit two tabs, in the same pill style as Omarchy's network
 panel. **Connections** holds everywhere you can go: recent places, and the
 country and city lists. **Protection** holds everything about *how* you're
-protected: the Kill Switch, NetShield, port forwarding, Always On, split
+protected: the Kill Switch, NetShield, Always On, port forwarding, split
 tunneling, and your
 account. The tab you pick stays until you close the panel.
 
@@ -345,7 +345,10 @@ the widget steps down to that automatically instead of failing.
 For torrent clients. When on, connecting to a **P2P server** (Quick connect →
 P2P, or any city whose servers carry the P2P flag) asks Proton for an inbound
 port, and the panel shows it as a **Forwarded port** row you click to copy. On
-any other server there is no port and the switch says so.
+any other server there is no port and the switch says so. Turning it on asks
+first, like the Kill Switch does, because it opens an inbound port on your VPN
+address and sends whatever arrives there to this computer. Turning it off is
+immediate.
 
 Proton hands the port out over NAT-PMP from the tunnel gateway and drops it
 unless it's renewed, which is why Proton's guide has you run a `natpmpc` loop

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 Under Quick Connect sit two tabs, in the same pill style as Omarchy's network
 panel. **Connections** holds everywhere you can go: recent places, and the
 country and city lists. **Protection** holds everything about *how* you're
-protected: the Kill Switch, NetShield, Always On, split tunneling, and your
+protected: the Kill Switch, NetShield, port forwarding, Always On, split
+tunneling, and your
 account. The tab you pick stays until you close the panel.
 
 The Protection tab has enough rules behind it to deserve its own chapter:
@@ -252,6 +253,10 @@ exactly what `protonvpn status` prints.
 The **Server** line updates within seconds from NetworkManager even while a
 connect is still in progress. The other rows come from the CLI and can lag a
 moment behind.
+
+With [port forwarding](#port-forwarding) on and a P2P server connected, a
+**Forwarded port** row appears. Click it to copy the number; it reads "Copied"
+for a moment. Paste it into your torrent client's listening port.
 
 ### Traffic
 
@@ -334,6 +339,22 @@ Blocks malware, ads, and trackers at the DNS level, on Proton's side. Three
 levels: off, malware only, or malware plus ads and trackers. The switch asks
 for the full level; on a free plan Proton only allows malware blocking, and
 the widget steps down to that automatically instead of failing.
+
+### Port forwarding
+
+For torrent clients. When on, connecting to a **P2P server** (Quick connect →
+P2P, or any city whose servers carry the P2P flag) asks Proton for an inbound
+port, and the panel shows it as a **Forwarded port** row you click to copy. On
+any other server there is no port and the switch says so.
+
+Proton hands the port out over NAT-PMP from the tunnel gateway and drops it
+unless it's renewed, which is why Proton's guide has you run a `natpmpc` loop
+in a terminal. The switch is that loop: while it's on and the tunnel is up,
+the widget renews the mapping every 45 seconds with a small script of its own
+(`port.py`, standard library only, no `natpmpc` to install). Turn it off and
+the renewals stop. Off by default: a forwarded port is an open inbound door,
+and nobody gets one without asking. Paid plans only, like the other Proton
+features.
 
 ### Always On
 
@@ -494,7 +515,11 @@ This plugin runs unsandboxed inside the Omarchy shell process, like every
 Omarchy plugin. It:
 
 - stores no credentials, tokens, or account data
-- makes no network requests of its own
+- makes no network requests of its own, with one exception you switch on:
+  with port forwarding on and the tunnel up, `port.py` sends a NAT-PMP renewal
+  to the VPN gateway (`10.2.0.1`, inside the tunnel) every 45 seconds. That is
+  the same exchange Proton's own guide has you run, it goes nowhere else, and
+  copying the port to the clipboard is the only thing done with the answer
 - never asks for root, the CLI install runs through Omarchy's own installer
   in a terminal that owns the password prompt
 - never downloads or executes remote code
@@ -517,7 +542,7 @@ allow-list, letters, digits, and `. _ + @ -` only, and single-quoted before
 it goes anywhere; anything else is refused with a message, not escaped. The
 terminal runs non-interactively, so nothing lands in your shell history.
 
-**Settings writes.** The Kill Switch and NetShield switches run
+**Settings writes.** The Kill Switch, NetShield and port forwarding switches run
 `protonvpn config set`. The widget will only ever pass `kill-switch` ∈
 `{off, standard}` and `netshield` ∈ `{off, malware-only, malware-ads-trackers}`;
 no other key or value can reach the CLI from this code.

--- a/Service.qml
+++ b/Service.qml
@@ -91,11 +91,46 @@ Item {
   property bool configLoaded: false
   readonly property bool killSwitchOn: String(config["kill-switch"] || "") === "standard"
   readonly property bool netShieldOn: configLoaded && String(config["netshield"] || "off") !== "off"
+  readonly property bool portForwardingOn: configLoaded && String(config["port-forwarding"] || "off") === "on"
   // The only values setConfig() will ever pass to the CLI.
   readonly property var configValues: ({
     "kill-switch": ["off", "standard"],
-    "netshield": ["off", "malware-only", "malware-ads-trackers"]
+    "netshield": ["off", "malware-only", "malware-ads-trackers"],
+    "port-forwarding": ["off", "on"]
   })
+
+  // The port Proton assigned on a P2P server, or "" when there isn't one.
+  //
+  // Proton hands it out over NAT-PMP on the tunnel gateway and drops the
+  // mapping unless it's renewed, which is why Proton's guide runs natpmpc in
+  // a loop. The CLI's own agent does the same exchange but only while a
+  // `protonvpn` process is alive, so a bare `status` poll rarely completes
+  // it. port.py is that exchange: while the switch is on and the tunnel is
+  // up it runs every 45 s (the guide's cadence against a 60 s lifetime),
+  // which both shows the port and keeps it. It's the one network request
+  // the widget makes, to 10.2.0.1 inside the tunnel, never anywhere else.
+  property string forwardedPort: ""
+  readonly property string portScriptPath: Qt.resolvedUrl("port.py").toString().replace(/^file:\/\//, "")
+  readonly property bool portWanted: portForwardingOn && connected && linkActive && !busy
+
+  onPortWantedChanged: {
+    if (portWanted) refreshPort()
+    else forwardedPort = ""
+  }
+
+  function refreshPort() {
+    if (!portWanted || portProcess.running) return
+    portProcess.command = ["python3", portScriptPath]
+    portProcess.running = true
+  }
+
+  onConnectedChanged: if (!connected) forwardedPort = ""
+
+  // Copy is the only thing the widget ever does with the port.
+  function copyForwardedPort() {
+    if (forwardedPort === "") return
+    Quickshell.execDetached(["wl-copy", forwardedPort])
+  }
 
   // Persisted across restarts: last few places connected to, and whether the
   // kill-switch nudge was dismissed. Location labels only, nothing secret.
@@ -575,6 +610,7 @@ Item {
   // Full protection first; the CLI refuses ads/trackers on a free plan and
   // the retry below steps down to malware-only.
   function toggleNetShield() { setConfig("netshield", netShieldOn ? "off" : "malware-ads-trackers") }
+  function togglePortForwarding() { setConfig("port-forwarding", portForwardingOn ? "off" : "on") }
 
   function dismissNudge() {
     nudgeDismissed = true
@@ -672,7 +708,11 @@ Item {
     locateProcess.running = true
   }
 
-  onDisplayServerChanged: locateServer(displayServer)
+  onDisplayServerChanged: {
+    locateServer(displayServer)
+    // A different server means a different port, or none.
+    forwardedPort = ""
+  }
 
   function countryName(code) {
     var c = String(code || "").toUpperCase()
@@ -971,6 +1011,31 @@ Item {
     path: root.notificationIconPath
     printErrors: false
     atomicWrites: true
+  }
+
+  Timer {
+    interval: 45000
+    repeat: true
+    running: root.portWanted
+    onTriggered: root.refreshPort()
+  }
+
+  Process {
+    id: portProcess
+    running: false
+    command: []
+    stdout: StdioCollector { id: portStdout; waitForEnd: true }
+    onExited: function(exitCode) {
+      var port = ""
+      try {
+        var out = exitCode === 0 ? JSON.parse(String(portStdout.text || "{}")) : {}
+        if (out && out.port) port = String(out.port)
+      } catch (e) { port = "" }
+      // A missed renewal (one timeout) shouldn't blank the row for 45 s; a
+      // server change already clears it, and no port on a non-P2P server
+      // stays "" because nothing ever set it.
+      if (port !== "" || !root.portWanted) root.forwardedPort = port
+    }
   }
 
   FileView {

--- a/port.py
+++ b/port.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Ask the VPN gateway for the forwarded port, and keep it alive.
+
+Proton assigns an inbound port on P2P servers through NAT-PMP (RFC 6886) on
+the tunnel gateway, 10.2.0.1. The mapping lapses unless it is renewed, which
+is why Proton's guide runs `natpmpc` in a loop; the CLI's own agent does the
+same exchange but only for as long as a `protonvpn` process is alive. This
+is that exchange, in the standard library, printed as JSON:
+
+    {"port": 58197}     a mapping for UDP and TCP, good for `lifetime` seconds
+    {}                  no port: not a P2P server, port forwarding off, or no tunnel
+
+Both requests ask for external port 0 with a 60 second lifetime, the values
+Proton's guide uses, so the gateway hands back the port it already assigned
+to this session. Nothing is sent anywhere but the gateway inside the tunnel.
+"""
+import json
+import socket
+import struct
+import sys
+
+GATEWAY = "10.2.0.1"
+PORT = 5351
+LIFETIME = 60
+UDP, TCP = 1, 2
+
+
+def mapping(proto):
+    """One NAT-PMP mapping request. Returns the external port, or None."""
+    request = struct.pack("!BBHHHI", 0, proto, 0, 0, 0, LIFETIME)
+    timeout = 0.25
+    for _ in range(4):  # 250 ms, 500 ms, 1 s, 2 s: RFC 6886's backoff, shortened
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+                sock.settimeout(timeout)
+                sock.sendto(request, (GATEWAY, PORT))
+                data, _ = sock.recvfrom(64)
+        except (OSError, socket.timeout):
+            timeout *= 2
+            continue
+        if len(data) < 16:
+            return None
+        version, opcode, result, _epoch, _internal, external, _life = struct.unpack("!BBHIHHI", data[:16])
+        if version != 0 or opcode != 128 + proto or result != 0:
+            return None
+        return external
+    return None
+
+
+def main():
+    udp = mapping(UDP)
+    tcp = mapping(TCP)
+    port = udp if udp else tcp
+    print(json.dumps({"port": port} if port else {}, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #5

## What
- **Protection → Port forwarding** switch, third CLI-backed toggle after Kill Switch and NetShield (`protonvpn config set port-forwarding on|off`, same enum-gated `setConfig` path). Its description shows the state: off, waiting for a P2P server, or `Port 58197 on this server`.
- **Connection details → Forwarded port** row when a port is assigned. Click it to copy (`wl-copy`), it reads `Copied` for two seconds. Copy is the only thing the widget does with the port.
- README: new Port forwarding chapter, detail rows note, Protection list, and the Security section's one exception (below).

## How the port really works (tested on a Plus account)
Proton assigns the port over **NAT-PMP on the tunnel gateway (10.2.0.1)** and drops the mapping unless it's renewed, which is why Proton's guide has you run a `natpmpc` loop. The CLI's own agent does that exchange, but only while a `protonvpn` process is alive: `connect` completes it, the 30 s `status` poll usually exits first, and the `$XDG_RUNTIME_DIR/Proton/VPN/forwarded_port` file it writes is blanked by every short-lived process, so the file flaps. `proton.vpn.daemon` is only the split tunneling daemon; nothing holds the lease.

So the switch *is* the loop: `port.py` (standard library, ~80 ms, no `natpmpc` to install) does the NAT-PMP mapping for UDP and TCP with the guide's values and runs every 45 s while the switch is on and the tunnel is up. That both shows the port and keeps it alive. It is the one network request the widget makes, to the gateway inside the tunnel, never anywhere else, and it's documented as the exception to "makes no network requests".

## Files
- `port.py` (new): the NAT-PMP exchange, prints `{"port": N}` or `{}`.
- `Service.qml`: `portForwardingOn`, `forwardedPort`, `portWanted`, 45 s timer, `portProcess`, `togglePortForwarding()`, `copyForwardedPort()`.
- `Panel.qml`: the switch (Protection index 2, later indices shifted), `CopyPair` row, copy flash, debug fields.
- `README.md`.

## Verified live
- `port.py` against the tunnel: `{"port":58197}`, stable across 10+ minutes of renewals.
- Widget debug IPC reports `portForwarding: on, forwardedPort: 58197`; the row renders in the panel; `wl-copy`/`wl-paste` round-trips the number.
- Panel.qml and Service.qml load clean in the quickshell harness.

## Update
- The switch now sits **under Always On** (Kill Switch, NetShield, Always On, Port forwarding, Split tunneling).
- Turning it **on asks first**, like the Kill Switch: "Port forwarding opens an inbound port on your VPN address and sends whatever arrives on it to this computer. It's for torrent clients and only works on P2P servers. Turn it off again when you're done." Cancel is preselected; turning it off is immediate.
- Keyboard handling drives whichever confirm dialog is open (`openDialog`).