### PR TITLE
Panel: say when a P2P connect landed, and name the feature on the Server row

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -84,6 +84,11 @@ function parseStatus(raw) {
   }
 }
 
+// "CH-US#3", "IS-JP#1", "SE-FR#2": only CH, IS and SE are entry countries.
+function isSecureCore(name) {
+  return /^(CH|IS|SE)-[A-Z]{2}/i.test(String(name || "").trim())
+}
+
 // Secure Core servers are named for both hops: "CH-US#3" enters Switzerland
 // and exits US server 3. Show that as a route, "CH → US#3". Only CH, IS and
 // SE are entry countries, which keeps regional names like "US-TX#40" as-is.

--- a/Panel.qml
+++ b/Panel.qml
@@ -939,14 +939,11 @@ Panel {
                   hasCursor: root.cursorActive && root.focusSection === "quick" && root.quickIndex === index
                   title: modelData.label
                   subtitle: modelData.hint
-                  // ACTIVE when the server you're on has that feature, which
-                  // is what tells you the click landed.
-                  trailing: {
-                    var active = vpn.connected && (
-                      (modelData.key === "securecore" && Model.isSecureCore(vpn.displayServer))
-                      || (modelData.key === "p2p" && vpn.currentP2p))
-                    return active ? "ACTIVE" : (modelData.plus ? "PLUS" : "")
-                  }
+                  // Secure Core gets an ACTIVE tag; P2P doesn't, since most
+                  // servers permit it and the header already says when you
+                  // asked for it.
+                  trailing: modelData.key === "securecore" && vpn.connected && Model.isSecureCore(vpn.displayServer)
+                            ? "ACTIVE" : (modelData.plus ? "PLUS" : "")
                   enabled: !vpn.busy
                   onEntered: root.setCursorFromHover("quick", index)
                   onClicked: root.runQuick(modelData.key)

--- a/Panel.qml
+++ b/Panel.qml
@@ -119,8 +119,11 @@ Panel {
     if (vpn.connected) {
       var server = Model.routeLabel(vpn.displayServer)
       if (server === "") return "Protected"
-      // Two hops deserve saying so: shield-lock, the feature, then the route.
-      return Model.isSecureCore(vpn.displayServer) ? "\udb82\udd9d Secure Core · " + server : server
+      // The feature you asked for, then the server: two hops deserve saying
+      // so, and a P2P click should visibly have landed.
+      if (Model.isSecureCore(vpn.displayServer)) return "\udb82\udd9d Secure Core · " + server
+      if (vpn.p2pRequested && vpn.currentP2p) return "\udb81\udc97 P2P · " + server
+      return server
     }
     if (!vpn.accountProbed) return "Checking…"
     if (!vpn.signedIn) return "Signed out"
@@ -936,8 +939,14 @@ Panel {
                   hasCursor: root.cursorActive && root.focusSection === "quick" && root.quickIndex === index
                   title: modelData.label
                   subtitle: modelData.hint
-                  trailing: modelData.key === "securecore" && vpn.connected && Model.isSecureCore(vpn.displayServer)
-                            ? "ACTIVE" : (modelData.plus ? "PLUS" : "")
+                  // ACTIVE when the server you're on has that feature, which
+                  // is what tells you the click landed.
+                  trailing: {
+                    var active = vpn.connected && (
+                      (modelData.key === "securecore" && Model.isSecureCore(vpn.displayServer))
+                      || (modelData.key === "p2p" && vpn.currentP2p))
+                    return active ? "ACTIVE" : (modelData.plus ? "PLUS" : "")
+                  }
                   enabled: !vpn.busy
                   onEntered: root.setCursorFromHover("quick", index)
                   onClicked: root.runQuick(modelData.key)

--- a/Panel.qml
+++ b/Panel.qml
@@ -118,7 +118,9 @@ Panel {
     if (vpn.busy && vpn.pendingLabel !== "") return vpn.pendingLabel
     if (vpn.connected) {
       var server = Model.routeLabel(vpn.displayServer)
-      return server !== "" ? server : "Protected"
+      if (server === "") return "Protected"
+      // Two hops deserve saying so: shield-lock, the feature, then the route.
+      return Model.isSecureCore(vpn.displayServer) ? "\udb82\udd9d Secure Core · " + server : server
     }
     if (!vpn.accountProbed) return "Checking…"
     if (!vpn.signedIn) return "Signed out"
@@ -934,7 +936,8 @@ Panel {
                   hasCursor: root.cursorActive && root.focusSection === "quick" && root.quickIndex === index
                   title: modelData.label
                   subtitle: modelData.hint
-                  trailing: modelData.plus ? "PLUS" : ""
+                  trailing: modelData.key === "securecore" && vpn.connected && Model.isSecureCore(vpn.displayServer)
+                            ? "ACTIVE" : (modelData.plus ? "PLUS" : "")
                   enabled: !vpn.busy
                   onEntered: root.setCursorFromHover("quick", index)
                   onClicked: root.runQuick(modelData.key)

--- a/Panel.qml
+++ b/Panel.qml
@@ -817,7 +817,17 @@ Panel {
             width: parent.width
             spacing: Style.spacing.labelGap
 
-            InfoPair { label: "Server"; value: vpn.displayServer }
+            // The server, and the feature it's serving: the route for Secure
+            // Core, P2P when that's what you asked for. Same rule as the header.
+            InfoPair {
+              label: "Server"
+              value: {
+                var name = vpn.displayServer
+                if (Model.isSecureCore(name)) return Model.routeLabel(name) + " · Secure Core"
+                if (vpn.p2pRequested && vpn.currentP2p) return name + " · P2P"
+                return name
+              }
+            }
             InfoPair { visible: vpn.location !== ""; label: "Location"; value: vpn.location }
 
             Repeater {

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ pick a country here; Proton picks the best match for you.
 Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 "Requires a Proton VPN Plus plan", nothing breaks.
 
+The **P2P** row shows an **ACTIVE** tag while the server you're on permits
+P2P, and the header reads "󰒗 P2P · US-TX#40" when that row is how you got
+there. (Most Proton servers permit P2P, so the header only makes a point of it
+when you asked.)
+
 While you're on Secure Core the panel says so three ways: the header reads
 "󰦝 Secure Core · CH → US#3" (the entry country, then the exit server), the
 Secure Core row carries an **ACTIVE** tag, and the map draws the route from the

--- a/README.md
+++ b/README.md
@@ -192,10 +192,9 @@ pick a country here; Proton picks the best match for you.
 Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 "Requires a Proton VPN Plus plan", nothing breaks.
 
-The **P2P** row shows an **ACTIVE** tag while the server you're on permits
-P2P, and the header reads "󰒗 P2P · US-TX#40" when that row is how you got
-there. (Most Proton servers permit P2P, so the header only makes a point of it
-when you asked.)
+After a **P2P** connect the header reads "󰒗 P2P · US-TX#40", so you can see
+the click landed. Most Proton servers permit P2P, so the panel only makes a
+point of it when that's what you asked for.
 
 While you're on Secure Core the panel says so three ways: the header reads
 "󰦝 Secure Core · CH → US#3" (the entry country, then the exit server), the

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ pick a country here; Proton picks the best match for you.
 Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 "Requires a Proton VPN Plus plan", nothing breaks.
 
+While you're on Secure Core the panel says so three ways: the header reads
+"󰦝 Secure Core · CH → US#3" (the entry country, then the exit server), the
+Secure Core row carries an **ACTIVE** tag, and the map draws the route from the
+entry country to the city you exit from.
+
 ### Two tabs: Connections and Protection
 
 Under Quick Connect sit two tabs, in the same pill style as Omarchy's network
@@ -465,7 +470,9 @@ signing out also disconnects.
 
 If the VPN drops unexpectedly you get a desktop notification, "VPN
 Disconnected, You're no longer protected." Connecting shows "VPN Connected"
-with the server and the protocol. Turn both off in the widget's settings if you'd rather not.
+with the server and the protocol. Neither shows while the panel is open, since
+the panel already tells you. Turn both off in the widget's settings if you'd
+rather not.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -192,14 +192,15 @@ pick a country here; Proton picks the best match for you.
 Rows marked **PLUS** need a paid plan. On a free plan they fail with a clear
 "Requires a Proton VPN Plus plan", nothing breaks.
 
-After a **P2P** connect the header reads "󰒗 P2P · US-TX#40", so you can see
-the click landed. Most Proton servers permit P2P, so the panel only makes a
+After a **P2P** connect the header reads "󰒗 P2P · US-TX#40" and the Server
+row "US-TX#40 · P2P", so you can see the click landed. Most Proton servers permit P2P, so the panel only makes a
 point of it when that's what you asked for.
 
 While you're on Secure Core the panel says so three ways: the header reads
 "󰦝 Secure Core · CH → US#3" (the entry country, then the exit server), the
-Secure Core row carries an **ACTIVE** tag, and the map draws the route from the
-entry country to the city you exit from.
+Server row reads "CH → US#3 · Secure Core", the Secure Core row carries an
+**ACTIVE** tag, and the map draws the route from the entry country to the city
+you exit from.
 
 ### Two tabs: Connections and Protection
 

--- a/Service.qml
+++ b/Service.qml
@@ -597,8 +597,15 @@ Item {
 
   // target: {key, title, subtitle, args} recorded to recents on success, or
   // null for quick actions that are already one click away.
+  // Whether the current connection was asked for with the P2P row: most
+  // servers permit P2P, so the panel only headlines it when that's what you
+  // clicked. Not persisted; after a restart the header shows the name.
+  property bool p2pRequested: false
+  readonly property bool currentP2p: !!(currentPlace && currentPlace.p2p === true)
+
   function connectTo(args, label, target, auto) {
     if (!installed || !signedIn || busy) return
+    p2pRequested = args.indexOf("--p2p") !== -1
     _autoAttempt = auto === true
     _desired = 1
     _expectDown = false

--- a/servers.py
+++ b/servers.py
@@ -144,12 +144,16 @@ def locate(data, name):
         if (s.get("Name") or "").upper() != want:
             continue
         loc = s.get("Location") or {}
+        features = s.get("Features") or 0
         place = {
             "name": s.get("Name") or "",
             "code": (s.get("ExitCountry") or "").upper(),
             "city": (s.get("City") or "").strip(),
             "lat": loc.get("Lat"),
             "lon": loc.get("Long"),
+            # Feature bit 4 is P2P. Most servers permit it, so the panel only
+            # makes a point of it when that's what you asked for.
+            "p2p": bool(features & P2P),
         }
         entry_code = (s.get("EntryCountry") or "").upper()
         if (s.get("Features") or 0) & SECURE_CORE and entry_code and entry_code != place["code"]:


### PR DESCRIPTION
Follow-up to #23 (these commits landed on the branch after it was merged).

## What
- `servers.py --locate` reports whether the server permits P2P (feature bit 4).
- After a **P2P** connect the header reads `󰒗 P2P · US-TX#561`. Only then: ~85% of Proton servers permit P2P, so a badge on every connection would be noise. Not persisted across a shell restart.
- The **Server** detail row names the feature too: `CH → US#3 · Secure Core`, `US-TX#561 · P2P`, plain name otherwise.
- No ACTIVE tag on the P2P row (it lit up on ordinary connections). Secure Core keeps its tag.
- README updated.

## Verified
- `--locate US-TX#561` returns `p2p: true`.
- Panel.qml loads clean in the quickshell harness; ran live in the shell with no QML warnings.