### PR TITLE
Hardening pass on the notification and port forwarding paths

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -107,7 +107,15 @@ function protocolLabel(raw) {
   if (p === "openvpn-udp" || p === "openvpn_udp") return "OpenVPN UDP"
   if (p === "openvpn-tcp" || p === "openvpn_tcp") return "OpenVPN TCP"
   if (p.indexOf("openvpn") === 0) return "OpenVPN"
+  // Anything else is shown only if it looks like a protocol name.
+  if (!/^[a-z0-9_-]{1,32}$/.test(p)) return ""
   return p.charAt(0).toUpperCase() + p.slice(1)
+}
+
+// Notification bodies are rendered as markup by the shell, so text that came
+// from the CLI is escaped before it goes into one.
+function escapeMarkup(s) {
+  return String(s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 }
 
 // `protonvpn info` -> "Account: 'user@example.com'", or "Account: 'None'"

--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ protonvpn disconnect
 protonvpn signout
 ```
 
-The widget also keeps a small file of your recent locations at
-`~/.local/state/omarchy-protonvpn/state.json`; delete it if you like.
+The widget also keeps a small folder of its own at
+`~/.local/state/omarchy-protonvpn/` (your recent locations and the icon it
+uses in notifications); delete it if you like.
 
 ## How to use it
 
@@ -321,13 +322,14 @@ the row that lands under the pointer would drag the selection back to itself.
 
 <img src="docs/protection-tab.png" width="360" alt="The Protection tab: Kill Switch, NetShield, Always On and split tunneling switches, the Mode and Apps pickers, account, and sign out">
 
-Four switches, three owners. Knowing who owns each one explains most of how
+Five switches, three owners. Knowing who owns each one explains most of how
 they behave:
 
 | Switch | Saved by | Where | Needs |
 | --- | --- | --- | --- |
 | **Kill Switch** | Proton CLI (`protonvpn config set`) | Proton's settings | Tunnel down to change |
 | **NetShield** | Proton CLI (`protonvpn config set`) | Proton's settings | Plus plan for ads and trackers |
+| **Port forwarding** | Proton CLI (`protonvpn config set`) | Proton's settings | Plus plan, and a P2P server for a port |
 | **Always On** | This widget | `~/.local/state/omarchy-protonvpn/state.json` | Nothing |
 | **Split tunneling** | This widget, editing Proton's file | `~/.config/Proton/VPN/settings.json` | Kill Switch off |
 
@@ -534,7 +536,8 @@ Omarchy plugin. It:
   with port forwarding on and the tunnel up, `port.py` sends a NAT-PMP renewal
   to the VPN gateway (`10.2.0.1`, inside the tunnel) every 45 seconds. That is
   the same exchange Proton's own guide has you run, it goes nowhere else, and
-  copying the port to the clipboard is the only thing done with the answer
+  the answer is only shown in the panel and copied to the clipboard when you
+  click it
 - never asks for root, the CLI install runs through Omarchy's own installer
   in a terminal that owns the password prompt
 - never downloads or executes remote code
@@ -543,9 +546,10 @@ Omarchy plugin. It:
 - reads Proton's server cache read-only (city list, coordinates, and the map's
   connected-city lookup all come from it), reads the tunnel's byte counters
   under `/sys/class/net/` once a second while the panel is open, and writes
-  one file of its own
-  (`~/.local/state/omarchy-protonvpn/state.json`: recent location labels,
-  whether you dismissed the Kill Switch prompt, and whether Always On is on)
+  two files of its own under `~/.local/state/omarchy-protonvpn/`
+  (`state.json`: recent location labels, whether you dismissed the Kill
+  Switch prompt, and whether Always On is on; `notification-icon.svg`: the
+  Proton mark in your theme's colour, for the notification)
 - writes one file that isn't its own, and only if you turn split tunneling on:
   `~/.config/Proton/VPN/settings.json`, Proton's own settings. Rules below.
 
@@ -559,8 +563,9 @@ terminal runs non-interactively, so nothing lands in your shell history.
 
 **Settings writes.** The Kill Switch, NetShield and port forwarding switches run
 `protonvpn config set`. The widget will only ever pass `kill-switch` ∈
-`{off, standard}` and `netshield` ∈ `{off, malware-only, malware-ads-trackers}`;
-no other key or value can reach the CLI from this code.
+`{off, standard}`, `netshield` ∈ `{off, malware-only, malware-ads-trackers}`
+and `port-forwarding` ∈ `{off, on}`; no other key or value can reach the CLI
+from this code.
 
 **Writing Proton's settings file.** Split tunneling is the one feature with no
 CLI command behind it, so the widget edits `~/.config/Proton/VPN/settings.json`
@@ -599,7 +604,8 @@ every ~3 hours, and only while connected. The widget's polling doesn't add API
 traffic beyond what the client already does on its own schedule.
 
 **Notifications** are sent straight to the desktop notification service over
-D-Bus and contain only the connection state and server name.
+D-Bus and contain only the connection state, the server and its location, and
+the protocol.
 
 **On screen.** Your Proton account email is shown only under Protection →
 Account, not in the panel's default view, but if you screenshot or

--- a/Service.qml
+++ b/Service.qml
@@ -129,7 +129,7 @@ Item {
   // Copy is the only thing the widget ever does with the port.
   function copyForwardedPort() {
     if (forwardedPort === "") return
-    Quickshell.execDetached(["wl-copy", forwardedPort])
+    Quickshell.execDetached(["wl-copy", "--", forwardedPort])
   }
 
   // Persisted across restarts: last few places connected to, and whether the
@@ -843,7 +843,7 @@ Item {
     Quickshell.execDetached(["busctl", "--user", "--", "call",
                              "org.freedesktop.Notifications", "/org/freedesktop/Notifications",
                              "org.freedesktop.Notifications", "Notify", "susssasa{sv}i",
-                             "OmaProton VPN", "0", notificationIconPath, summary, body || "",
+                             "OmaProton VPN", "0", notificationIconPath, summary, Model.escapeMarkup(body),
                              "0",
                              "2", "urgency", "y", level, "omarchy-glyph", "s", "\udb82\udd9d",
                              "-1"])
@@ -981,8 +981,16 @@ Item {
     // Owner-only, and fixed up on existing installs too: the file holds where
     // you've been connecting, which is nobody else's business on a shared box.
     Quickshell.execDetached(["install", "-d", "-m", "700", stateDir])
-    writeNotificationIcon()
     refresh()
+  }
+
+  // The state dir is created by a detached process, so the icon is written
+  // a moment later rather than racing it on a first launch.
+  Timer {
+    interval: 1000
+    running: true
+    repeat: false
+    onTriggered: root.writeNotificationIcon()
   }
 
   Connections {
@@ -1038,6 +1046,8 @@ Item {
         var out = exitCode === 0 ? JSON.parse(String(portStdout.text || "{}")) : {}
         if (out && out.port) port = String(out.port)
       } catch (e) { port = "" }
+      // Digits only, or nothing: this is what goes to the clipboard.
+      if (!/^[1-9][0-9]{0,4}$/.test(port)) port = ""
       // A missed renewal (one timeout) shouldn't blank the row for 45 s; a
       // server change already clears it, and no port on a non-P2P server
       // stays "" because nothing ever set it.

--- a/port.py
+++ b/port.py
@@ -33,8 +33,11 @@ def mapping(proto):
         try:
             with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
                 sock.settimeout(timeout)
-                sock.sendto(request, (GATEWAY, PORT))
-                data, _ = sock.recvfrom(64)
+                # Connected, so the kernel only delivers replies from the
+                # gateway and anything else that reaches the port is dropped.
+                sock.connect((GATEWAY, PORT))
+                sock.send(request)
+                data = sock.recv(64)
         except (OSError, socket.timeout):
             timeout *= 2
             continue


### PR DESCRIPTION
Follow-up review of everything merged since `main` (#22 to #26). No high or medium findings; these close the low ones and bring the README back in line with the code.

## Code
- **Notification body escaping**: the shell renders bodies as markup, and the connect body carries the CLI's server line and the protocol. `Model.escapeMarkup` runs on every body; `protocolLabel` returns "" for anything that doesn't look like a protocol name.
- **port.py**: connected UDP socket (`connect`/`send`/`recv`) so only the gateway's replies are delivered. Verified live: `{"port":55666}`.
- **Forwarded port**: validated as `^[1-9][0-9]{0,4}$` before it is shown or copied; `wl-copy -- <port>`.
- **Icon write**: one-second timer after launch instead of racing the detached `install -d` on a fresh install.

## README
- State dir holds two files (`state.json`, `notification-icon.svg`); Remove section updated.
- `port-forwarding ∈ {off, on}` added to the settings allow-list.
- Switches table gains the Port forwarding row.
- Notification contents and the port wording match the code.

## Verified
- Panel.qml and Service.qml load clean in the quickshell harness; the icon lands in the state dir after the timer.
- Every spawn site remains a literal argv list; no shell anywhere.