### PR TITLE
Mark NetShield as Plus feature

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1063,7 +1063,7 @@ Panel {
 
               Toggle {
                 width: parent.width
-                label: "NetShield"
+                label: "NetShield · PLUS"
                 description: {
                   var applying = vpn.configPendingLabel("netshield")
                   if (applying !== "") return applying


### PR DESCRIPTION
## Summary
- mark the NetShield protection toggle as a Plus feature in the UI

## Validation
- `git diff --check`
- `qmllint -I /usr/share/omarchy/shell/Commons -I /usr/share/omarchy/shell/Ui -I /usr/share/omarchy/shell Panel.qml` currently exits 255 without diagnostics, matching `origin/main:Panel.qml`
- `qmlformat Panel.qml` currently exits 1 without diagnostics, matching `origin/main:Panel.qml`

Closes #34