### PR TITLE
Release 1.4.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.grichard99.omaproton-vpn",
   "name": "OmaProton VPN",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": "grichard99",
   "license": "MIT",
   "description": "Proton VPN, built for Omarchy. No terminal: one click to connect, a world map of cities, Kill Switch, in a widget that wears every Omarchy theme.",


### PR DESCRIPTION
Bumps the manifest version to 1.4.2 for the docs release (Tailscale section, table of contents rework). `omarchy plugin validate` passes and the pre-release keyword check on the tree is clean. Part of the 1.4.2 release train; staging merges to main next.