### PR TITLE
fix: Split tunneling row stuck on "Sign in and connect once first"

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -303,6 +303,15 @@ Item {
     _watchStartedMs = Date.now()
     watchProcess.command = ["nmcli", "-t", "-f", "NAME,TYPE,DEVICE,STATE", "connection", "show", "--active"]
     watchProcess.running = true
+
+    // Proton's own file watch can go stale: if the CLI/app rewrote
+    // settings.json (say, adding the `features` block on a first connect)
+    // before this plugin ever read one, or the rewrite happened between two
+    // inotify events, protonSettings is left stuck null with nothing left to
+    // trigger a re-read. Piggyback this same periodic tick to retry, so the
+    // Split tunneling row heals itself in a few seconds instead of needing a
+    // shell restart.
+    if (!protonSettings) protonFile.reload()
   }
 
   function refreshStatus() {


### PR DESCRIPTION
## Problem

The Split tunneling row can get permanently stuck showing "Sign in and
connect once first", even with the Kill Switch off and a valid
`features.split_tunneling` block already present in
`~/.config/Proton/VPN/settings.json`.

## Cause

`protonSettings` is only ever populated from the `protonFile` FileView's
`onLoaded`/`onFileChanged` handlers. If Proton's app/CLI rewrites
`settings.json` (e.g. adding the `features` block on a user's first
connect) before this plugin's first successful read, or the file changes
between two watch events, `protonSettings` is left `null` with nothing
left to trigger a retry. `splitAvailable` then stays false forever, and
the only recovery is restarting the shell.

Reproduced and confirmed on a live machine: the row was stuck on "Sign in
and connect once first" with a perfectly valid, readable settings file;
restarting the shell (forcing a fresh `FileView` read) immediately fixed
it, isolating this as a stale-watch issue rather than a permissions or
parsing bug.

## Fix

`watchLink()` already runs on a periodic timer (`watchIntervalSec`, every
few seconds while the panel/plugin is active). This piggybacks that same
tick: if `protonSettings` is still `null`, retry `protonFile.reload()`.
The row now self-heals within one tick instead of requiring a shell
restart.

Minimal, single-file change, no new timers.