### PR TITLE
Tag NetShield as a Plus feature

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1068,10 +1068,13 @@ Panel {
                   var applying = vpn.configPendingLabel("netshield")
                   if (applying !== "") return applying
                   if (!vpn.configLoaded) return "Loading…"
+                  // Says which half needs Plus, the same tag the Quick
+                  // Connect rows wear, so a free account isn't left wondering
+                  // why the switch came on but the ads didn't stop.
                   var v = String(vpn.config["netshield"] || "off")
                   if (v === "malware-ads-trackers") return "Blocking malware, ads and trackers"
-                  if (v === "malware-only") return "Blocking malware"
-                  return "Block malware, ads and trackers"
+                  if (v === "malware-only") return "Blocking malware · Ads and trackers need Plus"
+                  return "Block malware, ads and trackers · Plus"
                 }
                 checked: vpn.netShieldOn
                 enabled: vpn.configLoaded && vpn.configPending === ""

--- a/README.md
+++ b/README.md
@@ -353,7 +353,9 @@ independently of the tunnel.
 Blocks malware, ads, and trackers at the DNS level, on Proton's side. Three
 levels: off, malware only, or malware plus ads and trackers. The switch asks
 for the full level; on a free plan Proton only allows malware blocking, and
-the widget steps down to that automatically instead of failing.
+the widget steps down to that automatically instead of failing. The row is
+tagged Plus, and once stepped down it says that ads and trackers need Plus,
+so a free account knows what it got.
 
 ### Always On
 


### PR DESCRIPTION
Closes #34

## What it does

The NetShield row on the Protection tab now says which part of it needs a paid plan, in the description slot the row already has, using the same "Plus" tag the Quick Connect rows wear.

| State | Description |
| --- | --- |
| Off | Block malware, ads and trackers · Plus |
| Stepped down to malware only | Blocking malware · Ads and trackers need Plus |
| Full | Blocking malware, ads and trackers (unchanged) |

The stepped-down line is the one that matters for a free account: the widget already retries at malware-only when the CLI refuses the full level, so the switch comes on, and until now nothing said the ads and trackers half was skipped.

## What came with it

- README's NetShield section notes the tag and the stepped-down wording.

## Tested

Standalone quickshell harness loads the Panel clean. The wording is a pure binding on the existing config value, no service change. Not checked against a live free account.

## Deliberately not in it

- No gating on the probed plan string. The tag is shown for everyone, like the Quick Connect rows, because the plan wording the CLI prints isn't documented and the tag is true either way.
