### PR TITLE
Put the PLUS tag on the NetShield label's line

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1261,19 +1261,19 @@ Panel {
               }
 
               Toggle {
+                id: netShieldRow
                 width: parent.width
                 label: "NetShield"
                 description: {
                   var applying = vpn.configPendingLabel("netshield")
                   if (applying !== "") return applying
                   if (!vpn.configLoaded) return "Loading…"
-                  // Says which half needs Plus, the same tag the Quick
-                  // Connect rows wear, so a free account isn't left wondering
-                  // why the switch came on but the ads didn't stop.
+                  // Once stepped down on a free plan, say which half was
+                  // skipped, or the switch comes on and the ads don't stop.
                   var v = String(vpn.config["netshield"] || "off")
                   if (v === "malware-ads-trackers") return "Blocking malware, ads and trackers"
                   if (v === "malware-only") return "Blocking malware · Ads and trackers need Plus"
-                  return "Block malware, ads and trackers · Plus"
+                  return "Block malware, ads and trackers"
                 }
                 checked: vpn.netShieldOn
                 enabled: vpn.configLoaded && vpn.configPending === ""
@@ -1282,6 +1282,10 @@ Panel {
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursorFromHover("protection", 1) }
                 onClicked: { root.clearHighlight(); vpn.toggleNetShield() }
+
+                // The same PLUS tag the Quick Connect rows wear, on the
+                // label's line.
+                LabelTag { row: netShieldRow; text: "PLUS" }
               }
 
               // Widget-owned, unlike the two above: the CLI has no setting for
@@ -1875,6 +1879,44 @@ Panel {
           onClicked: { root.clearHighlight(); actionRow.editClicked() }
         }
       }
+    }
+  }
+
+  // A tag on the same line as a Toggle's label, after the label's text. The
+  // shell's Toggle has no trailing slot, so this sits over the row, placed
+  // off the bold label Text the Toggle draws and that text's own metrics. A
+  // Text takes no clicks, so the row underneath still owns the switch.
+  component LabelTag: Text {
+    id: tag
+    property Item row: null
+    // The Toggle's label: the first bold Text under the row.
+    readonly property Item labelItem: findLabel(row)
+    function findLabel(item) {
+      for (var i = 0; item && i < item.children.length; i++) {
+        var c = item.children[i]
+        if (c.font !== undefined && c.text !== undefined && c.font.bold === true) return c
+        var r = findLabel(c)
+        if (r) return r
+      }
+      return null
+    }
+    // Row > Column > Text: three levels between the label and the row.
+    readonly property Item labelColumn: labelItem ? labelItem.parent : null
+    readonly property Item labelRow: labelColumn ? labelColumn.parent : null
+
+    parent: row
+    visible: labelItem !== null && text !== ""
+    x: labelItem ? labelRow.x + labelColumn.x + labelItem.x + metrics.advanceWidth + Style.space(8) : 0
+    y: labelItem ? labelRow.y + labelColumn.y + labelItem.y + (labelItem.height - height) / 2 : 0
+    textFormat: Text.PlainText
+    color: root.dim
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.caption
+
+    TextMetrics {
+      id: metrics
+      font: tag.labelItem ? tag.labelItem.font : tag.font
+      text: tag.labelItem ? tag.labelItem.text : ""
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ independently of the tunnel.
 Blocks malware, ads, and trackers at the DNS level, on Proton's side. Three
 levels: off, malware only, or malware plus ads and trackers. The switch asks
 for the full level; on a free plan Proton only allows malware blocking, and
-the widget steps down to that automatically instead of failing. The row is
-tagged Plus, and once stepped down it says that ads and trackers need Plus,
-so a free account knows what it got.
+the widget steps down to that automatically instead of failing. The row wears
+the same PLUS tag as the Quick Connect rows, and once stepped down it says
+that ads and trackers need Plus, so a free account knows what it got.
 
 ### Always On
 


### PR DESCRIPTION
Follow-up to #43 and issue #34.

## What it does

The NetShield row now carries the same "PLUS" tag the Quick Connect rows wear, on the label's own line, right after the word NetShield. The off-state description goes back to plain "Block malware, ads and trackers". Once stepped down to malware only on a free plan, the description still says "Blocking malware · Ads and trackers need Plus", because that state is the one where a free account needs telling what it got.

## How

The shell's `Toggle` has a label and a description but no trailing slot. Rather than copy the shell component into the plugin, a small `LabelTag` Text is parented onto the row and positioned off the Toggle's own bold label Text: it finds that Text under the row, sums the three levels of offsets (Row, Column, Text), adds the label's advance width from `TextMetrics` in the label's font, and centres itself on the label's height. All of those are live properties, so it follows a re-layout. A Text takes no clicks, so the row's MouseArea still owns the switch.

The lookup is by structure ("the first bold Text under the row"), so if the shell restyles Toggle it degrades to the tag not showing, never to a broken row.

## Tested

Harness with the real Panel on the Protection tab: the tag is visible, starts 8px past the end of "NetShield" in the label's bold 13px font, and is vertically centred on the label line. No QML warnings.

## Not in it

- No gating on the account's tier. The tag shows for everyone, like the Quick Connect rows. Proton's server cache carries a `MaxTier` field that could gate it later if wanted.
