### PR TITLE
OmaProton VPN 1.4.4

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -96,12 +96,8 @@ Panel {
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
-  // Connected through a profile, the icon takes that profile's colour, in
-  // the panel and in the bar: which place you're on, at a glance, in a colour
-  // the theme already owns.
-  readonly property color profileTint: vpn.connected && vpn.activeProfileEntry ? themeColor(vpn.activeProfileEntry.color) : "transparent"
-  readonly property color iconColor: vpn.connected ? (vpn.activeProfileEntry ? profileTint : foreground) : dim
-  readonly property color barIconColor: vpn.connected ? (vpn.activeProfileEntry ? profileTint : barForeground) : Qt.darker(barForeground, 1.55)
+  readonly property color iconColor: vpn.connected ? foreground : dim
+  readonly property color barIconColor: vpn.connected ? barForeground : Qt.darker(barForeground, 1.55)
 
   // ── Theme palette ───────────────────────────────────────────────────────
   // The shell's Color only carries accent, foreground, background, urgent and

--- a/Panel.qml
+++ b/Panel.qml
@@ -1261,19 +1261,19 @@ Panel {
               }
 
               Toggle {
+                id: netShieldRow
                 width: parent.width
                 label: "NetShield"
                 description: {
                   var applying = vpn.configPendingLabel("netshield")
                   if (applying !== "") return applying
                   if (!vpn.configLoaded) return "Loading…"
-                  // Says which half needs Plus, the same tag the Quick
-                  // Connect rows wear, so a free account isn't left wondering
-                  // why the switch came on but the ads didn't stop.
+                  // Once stepped down on a free plan, say which half was
+                  // skipped, or the switch comes on and the ads don't stop.
                   var v = String(vpn.config["netshield"] || "off")
                   if (v === "malware-ads-trackers") return "Blocking malware, ads and trackers"
                   if (v === "malware-only") return "Blocking malware · Ads and trackers need Plus"
-                  return "Block malware, ads and trackers · Plus"
+                  return "Block malware, ads and trackers"
                 }
                 checked: vpn.netShieldOn
                 enabled: vpn.configLoaded && vpn.configPending === ""
@@ -1282,6 +1282,10 @@ Panel {
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursorFromHover("protection", 1) }
                 onClicked: { root.clearHighlight(); vpn.toggleNetShield() }
+
+                // The same PLUS tag the Quick Connect rows wear, on the
+                // label's line.
+                LabelTag { row: netShieldRow; text: "PLUS" }
               }
 
               // Widget-owned, unlike the two above: the CLI has no setting for
@@ -1875,6 +1879,44 @@ Panel {
           onClicked: { root.clearHighlight(); actionRow.editClicked() }
         }
       }
+    }
+  }
+
+  // A tag on the same line as a Toggle's label, after the label's text. The
+  // shell's Toggle has no trailing slot, so this sits over the row, placed
+  // off the bold label Text the Toggle draws and that text's own metrics. A
+  // Text takes no clicks, so the row underneath still owns the switch.
+  component LabelTag: Text {
+    id: tag
+    property Item row: null
+    // The Toggle's label: the first bold Text under the row.
+    readonly property Item labelItem: findLabel(row)
+    function findLabel(item) {
+      for (var i = 0; item && i < item.children.length; i++) {
+        var c = item.children[i]
+        if (c.font !== undefined && c.text !== undefined && c.font.bold === true) return c
+        var r = findLabel(c)
+        if (r) return r
+      }
+      return null
+    }
+    // Row > Column > Text: three levels between the label and the row.
+    readonly property Item labelColumn: labelItem ? labelItem.parent : null
+    readonly property Item labelRow: labelColumn ? labelColumn.parent : null
+
+    parent: row
+    visible: labelItem !== null && text !== ""
+    x: labelItem ? labelRow.x + labelColumn.x + labelItem.x + metrics.advanceWidth + Style.space(8) : 0
+    y: labelItem ? labelRow.y + labelColumn.y + labelItem.y + (labelItem.height - height) / 2 : 0
+    textFormat: Text.PlainText
+    color: root.dim
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.caption
+
+    TextMetrics {
+      id: metrics
+      font: tag.labelItem ? tag.labelItem.font : tag.font
+      text: tag.labelItem ? tag.labelItem.text : ""
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -1068,10 +1068,13 @@ Panel {
                   var applying = vpn.configPendingLabel("netshield")
                   if (applying !== "") return applying
                   if (!vpn.configLoaded) return "Loading…"
+                  // Says which half needs Plus, the same tag the Quick
+                  // Connect rows wear, so a free account isn't left wondering
+                  // why the switch came on but the ads didn't stop.
                   var v = String(vpn.config["netshield"] || "off")
                   if (v === "malware-ads-trackers") return "Blocking malware, ads and trackers"
-                  if (v === "malware-only") return "Blocking malware"
-                  return "Block malware, ads and trackers"
+                  if (v === "malware-only") return "Blocking malware · Ads and trackers need Plus"
+                  return "Block malware, ads and trackers · Plus"
                 }
                 checked: vpn.netShieldOn
                 enabled: vpn.configLoaded && vpn.configPending === ""

--- a/Panel.qml
+++ b/Panel.qml
@@ -72,6 +72,8 @@ Panel {
   onSplitDetailVisibleChanged: {
     if (protectionIndex >= protectionCount) protectionIndex = protectionCount - 1
   }
+  property int profileIndex: 0
+  property int editorIndex: 0
   property int recentIndex: 0
   property int countryIndex: 0
   property int serverIndex: 0
@@ -94,8 +96,176 @@ Panel {
   readonly property color dim: Qt.darker(foreground, 1.55)
   readonly property string fontFamily: bar ? bar.fontFamily : Style.font.family
 
-  readonly property color iconColor: vpn.connected ? foreground : dim
-  readonly property color barIconColor: vpn.connected ? barForeground : Qt.darker(barForeground, 1.55)
+  // Connected through a profile, the icon takes that profile's colour, in
+  // the panel and in the bar: which place you're on, at a glance, in a colour
+  // the theme already owns.
+  readonly property color profileTint: vpn.connected && vpn.activeProfileEntry ? themeColor(vpn.activeProfileEntry.color) : "transparent"
+  readonly property color iconColor: vpn.connected ? (vpn.activeProfileEntry ? profileTint : foreground) : dim
+  readonly property color barIconColor: vpn.connected ? (vpn.activeProfileEntry ? profileTint : barForeground) : Qt.darker(barForeground, 1.55)
+
+  // ── Theme palette ───────────────────────────────────────────────────────
+  // The shell's Color only carries accent, foreground, background, urgent and
+  // muted. A profile wants the rest of the theme's names (Tokyo Night's pinks
+  // and purples, Jade's greens), so colors.toml is read here too, with the
+  // same line rule the shell uses. Profiles store the name, never the hex,
+  // so a theme switch recolours every row on its own.
+  property var themePalette: ({})
+
+  function themeColor(name) {
+    var n = String(name || "")
+    if (n === "" || n === "accent") return Color.accent
+    var v = themePalette[n]
+    return v ? v : Color.accent
+  }
+
+  function loadPalette(raw) {
+    var lines = String(raw || "").split("\n")
+    var out = {}
+    for (var i = 0; i < lines.length; i++) {
+      var m = lines[i].match(/^\s*([A-Za-z0-9_-]+)\s*=\s*["']?(#[0-9A-Fa-f]{6})/)
+      if (m) out[m[1]] = m[2]
+    }
+    themePalette = out
+  }
+
+  FileView {
+    id: paletteFile
+    path: Color.currentThemePath + "/colors.toml"
+    watchChanges: false
+    printErrors: false
+    onLoaded: root.loadPalette(text())
+    onLoadFailed: root.themePalette = {}
+  }
+
+  // A theme switch reaches the shell as a new accent or foreground; the
+  // symlink under it has changed by then, so re-read the palette too.
+  Connections {
+    target: Color
+    function onAccentChanged() { paletteFile.reload() }
+    function onForegroundChanged() { paletteFile.reload() }
+    function onBackgroundChanged() { paletteFile.reload() }
+  }
+
+  // ── Profile editor ──────────────────────────────────────────────────────
+  // The draft being edited, or null. {id, isNew, color, where, feature,
+  // serverOption}; the name lives in nameField until Save. `where` is "",
+  // "random", "country:CC" or "server:NAME"; `serverOption` is the dropdown
+  // row for a named server, which the country list can't supply.
+  property var draft: null
+  readonly property var editorRows: draft === null ? []
+                                    : (draft.isNew ? ["name", "color", "where", "feature", "save", "cancel"]
+                                                   : ["name", "color", "where", "feature", "save", "cancel", "delete"])
+  readonly property string editorRow: draft !== null && editorIndex < editorRows.length ? editorRows[editorIndex] : ""
+  readonly property var featureOptions: [
+    { value: "", label: "None" },
+    { value: "p2p", label: "P2P" },
+    { value: "securecore", label: "Secure Core" },
+    { value: "tor", label: "Tor" }
+  ]
+  readonly property var whereOptions: {
+    var list = [
+      { value: "", label: "Fastest", description: "Best server for your location" },
+      { value: "random", label: "Random", description: "Any available server" }
+    ]
+    if (draft !== null && draft.serverOption) list.push(draft.serverOption)
+    for (var i = 0; i < vpn.countries.length; i++) {
+      list.push({ value: "country:" + vpn.countries[i].code, label: vpn.countries[i].name })
+    }
+    return list
+  }
+
+  function whereOf(args) {
+    for (var i = 0; i < args.length; i++) {
+      if (args[i] === "--country" && i + 1 < args.length) return "country:" + args[i + 1]
+      if (args[i] === "--random") return "random"
+      if (args[i].charAt(0) !== "-") return "server:" + args[i]
+    }
+    return ""
+  }
+
+  function featureOf(args) {
+    if (args.indexOf("--p2p") !== -1) return "p2p"
+    if (args.indexOf("--securecore") !== -1) return "securecore"
+    if (args.indexOf("--tor") !== -1) return "tor"
+    return ""
+  }
+
+  function setDraft(key, value) {
+    if (draft === null) return
+    var d = Object.assign({}, draft)
+    d[key] = value
+    draft = d
+  }
+
+  // Edit an existing profile, or start a new one where you are: the top of
+  // Recent is the place you last asked for, which is usually the one worth
+  // naming. Only the draft changes here; the state file waits for Save.
+  function openEditor(profile) {
+    clearHighlight()
+    var src = profile ? profile : (vpn.recents.length > 0 ? vpn.recents[0] : null)
+    var args = src && Array.isArray(src.args) ? src.args : []
+    var where = whereOf(args)
+    var d = {
+      id: profile ? profile.id : vpn.newProfileId(),
+      isNew: !profile,
+      color: profile ? profile.color : "accent",
+      where: where,
+      feature: featureOf(args),
+      serverOption: where.indexOf("server:") === 0 && src
+                    ? { value: where, label: src.title, description: src.subtitle } : null
+    }
+    nameField.text = profile ? profile.name : ""
+    draft = d
+    editorIndex = 0
+    cursorActive = true
+    focusSection = "editor"
+    Qt.callLater(function() { if (nameField.visible) nameField.forceActiveFocus() })
+  }
+
+  function closeEditor(selectId) {
+    draft = null
+    keyCatcher.forceActiveFocus()
+    focusSection = "profiles"
+    profileIndex = vpn.profiles.length
+    for (var i = 0; i < vpn.profiles.length; i++) if (vpn.profiles[i].id === selectId) profileIndex = i
+    ensureCursor()
+    scrollCursorIntoView()
+  }
+
+  function saveDraft() {
+    if (draft === null) return
+    var name = String(nameField.text || "").trim()
+    if (name === "") { nameField.forceActiveFocus(); return }
+    var so = draft.serverOption
+    var p = vpn.buildProfile(draft.id, name, draft.color, draft.where, draft.feature,
+                             so ? so.label : "", so ? so.description : "")
+    if (!p || !vpn.saveProfile(p)) return
+    closeEditor(p.id)
+  }
+
+  function deleteDraft() {
+    if (draft === null || draft.isNew) return
+    vpn.deleteProfile(draft.id)
+    closeEditor("")
+  }
+
+  function cycleColor(step) {
+    if (draft === null) return
+    var names = vpn.profileColors
+    var i = Math.max(0, names.indexOf(draft.color))
+    setDraft("color", names[(i + step + names.length) % names.length])
+  }
+
+  function activateEditorRow() {
+    var row = editorRow
+    if (row === "name") nameField.forceActiveFocus()
+    else if (row === "color") cycleColor(1)
+    else if (row === "where") whereRow.toggle()
+    else if (row === "feature") { if (featureRow.enabled) featureRow.toggle() }
+    else if (row === "save") saveDraft()
+    else if (row === "cancel") closeEditor(draft.id)
+    else if (row === "delete") deleteDraft()
+  }
 
   readonly property var quickActions: [
     { key: "fastest", label: "Fastest", hint: "Best server for your location", plus: false },
@@ -121,9 +291,12 @@ Panel {
       if (server === "") return "Protected"
       // The feature you asked for, then the server: two hops deserve saying
       // so, and a P2P click should visibly have landed.
-      if (Model.isSecureCore(vpn.displayServer)) return "\udb82\udd9d Secure Core · " + server
-      if (vpn.p2pRequested && vpn.currentP2p) return "\udb81\udc97 P2P · " + server
-      return server
+      var meta = server
+      if (Model.isSecureCore(vpn.displayServer)) meta = "\udb82\udd9d Secure Core · " + server
+      else if (vpn.p2pRequested && vpn.currentP2p) meta = "\udb81\udc97 P2P · " + server
+      // Through a profile, the name you gave the place leads.
+      var prof = vpn.activeProfileEntry
+      return prof ? prof.name + " · " + meta : meta
     }
     if (!vpn.accountProbed) return "Checking…"
     if (!vpn.signedIn) return "Signed out"
@@ -150,6 +323,10 @@ Panel {
     if (tab === "protection") {
       list.push({ name: "protection", count: protectionCount })
     } else {
+      // The profile rows plus the "New profile" row, or the editor's rows
+      // while one is open.
+      if (draft !== null) list.push({ name: "editor", count: editorRows.length })
+      else list.push({ name: "profiles", count: vpn.profiles.length + 1 })
       if (vpn.recents.length > 0) list.push({ name: "recents", count: vpn.recents.length })
       if (drilled) list.push({ name: "servers", count: serverRowCount })
       else if (filteredCountries.length > 0) list.push({ name: "countries", count: filteredCountries.length })
@@ -162,6 +339,8 @@ Panel {
     if (name === "tabs") return tabIndex
     if (name === "quick") return quickIndex
     if (name === "protection") return protectionIndex
+    if (name === "profiles") return profileIndex
+    if (name === "editor") return editorIndex
     if (name === "recents") return recentIndex
     if (name === "countries") return countryIndex
     if (name === "servers") return serverIndex
@@ -173,6 +352,8 @@ Panel {
     else if (name === "tabs") tabIndex = value
     else if (name === "quick") quickIndex = value
     else if (name === "protection") protectionIndex = value
+    else if (name === "profiles") profileIndex = value
+    else if (name === "editor") editorIndex = value
     else if (name === "recents") recentIndex = value
     else if (name === "countries") countryIndex = value
     else if (name === "servers") serverIndex = value
@@ -258,8 +439,10 @@ Panel {
     ensureCursor()
     if (dy !== 0) anchorPending = false
 
-    // Horizontal moves drill in and out of a country's server list.
+    // Horizontal moves drill in and out of a country's server list. In the
+    // editor they walk the colour swatches.
     if (dx !== 0) {
+      if (focusSection === "editor") { if (editorRow === "color") cycleColor(dx); return }
       if (dx > 0 && focusSection === "countries") drillInto(filteredCountries[countryIndex])
       else if (dx < 0 && focusSection === "servers") drillOut()
       return
@@ -305,6 +488,11 @@ Panel {
       else if (splitDetailVisible && protectionIndex === 6) splitAppsRow.toggle()
       else requestSignOut()
     }
+    else if (focusSection === "profiles") {
+      if (profileIndex < vpn.profiles.length) { vpn.connectProfile(vpn.profiles[profileIndex].id); showConnection() }
+      else openEditor(null)
+    }
+    else if (focusSection === "editor") activateEditorRow()
     else if (focusSection === "recents") { vpn.connectRecent(recentIndex); showConnection() }
     // Enter on a country opens its servers rather than connecting blind,
     // the first row inside is still "Fastest in <country>", so the old
@@ -417,10 +605,16 @@ Panel {
     else if (focusSection === "quick") column = quickColumn
     else if (focusSection === "tabs") column = tabRow
     else if (focusSection === "protection") column = protectionColumn
+    else if (focusSection === "profiles") column = profileColumn
+    else if (focusSection === "editor") column = editorColumn
     else if (focusSection === "recents") column = recentColumn
     else if (focusSection === "countries") column = countryColumn
     else if (focusSection === "servers") column = serverColumn
     var i = sectionIndex(focusSection)
+    // "New profile" is the last child of its column, after the Repeater.
+    if (focusSection === "profiles" && i >= vpn.profiles.length && column) i = column.children.length - 1
+    // The editor's three buttons share one row.
+    if (focusSection === "editor") i = Math.min(i, 4)
     // The Protection column carries the Account header and rows after its
     // switches; the sign-out row is its last child wherever the cursor for it
     // has ended up.
@@ -438,6 +632,8 @@ Panel {
       anchorPending = false
       cursorActive = false
       filterQuery = ""
+      draft = null
+      paletteFile.reload()
       vpn.clearServers()
       serverIndex = 0
       if (panelFlick) panelFlick.contentY = 0
@@ -578,8 +774,9 @@ Panel {
       // An open Mode or Apps popup owns the keyboard while it is up, or hjkl
       // would drive the cursor on the panel behind it, scrolling a list the
       // person can't see instead of moving inside the one they opened.
-      blocked: filterField.activeFocus || usernameField.activeFocus
+      blocked: filterField.activeFocus || usernameField.activeFocus || nameField.activeFocus
                || splitModeRow.popupOpen || splitAppsRow.popupOpen
+               || whereRow.popupOpen || featureRow.popupOpen
       onMoveRequested: function(dx, dy) {
         // A dialog with the screen dimmed behind it owns the keyboard, or the
         // cursor would be moving around underneath it unseen.
@@ -599,15 +796,21 @@ Panel {
         if (root.cursorActive) root.activateCursor()
       }
       // Inside a drill, escape backs out one level before it closes the panel.
+      // Inside the editor it drops the draft, the same way it backs out
+      // of a drill.
       onCloseRequested: {
         if (root.openDialog) { root.openDialog.canceled(); return }
+        if (root.draft !== null) { root.closeEditor(root.draft.id); return }
         root.drilled ? root.drillOut() : root.close()
       }
       onTabRequested: function(direction) { root.switchPanel(direction) }
-      // No single-letter actions on purpose: the panel takes keyboard focus
-      // when it opens, and a stray keystroke must never change the tunnel.
+      // No single-letter actions on the tunnel, on purpose: the panel takes
+      // keyboard focus when it opens, and a stray keystroke must never change
+      // it. "e" only opens the editor for the profile under the cursor.
       onTextKey: function(t) {
         if (t === "/") filterField.forceActiveFocus()
+        else if (t === "e" && root.cursorActive && root.focusSection === "profiles"
+                 && root.profileIndex < vpn.profiles.length) root.openEditor(vpn.profiles[root.profileIndex])
       }
 
       // What counts as the pointer actually moving. A row sliding under a
@@ -1226,6 +1429,203 @@ Panel {
             }
           }
 
+          // ── Profiles ────────────────────────────────────────────────────
+          // Named places in the theme's colours, above Recent. The editor
+          // takes the list's place while a profile is being written.
+          Column {
+            visible: vpn.signedIn && root.tab === "connections"
+            width: parent.width
+            spacing: Style.space(10)
+
+            PanelSectionHeader {
+              text: root.draft === null ? "PROFILES" : (root.draft.isNew ? "NEW PROFILE" : "EDIT PROFILE")
+              foreground: root.foreground
+              fontFamily: root.fontFamily
+            }
+
+            Column {
+              id: profileColumn
+              visible: root.draft === null
+              width: parent.width
+              spacing: Style.space(6)
+
+              Repeater {
+                model: vpn.profiles
+                ActionRow {
+                  required property var modelData
+                  required property int index
+                  width: profileColumn.width
+                  hasCursor: root.cursorActive && root.focusSection === "profiles" && root.profileIndex === index
+                  icon: "\udb81\udf65"
+                  iconColor: root.themeColor(modelData.color)
+                  title: modelData.name
+                  subtitle: [modelData.title, modelData.subtitle].filter(function(v) { return v !== "" }).join(" · ")
+                  trailing: vpn.connected && vpn.activeProfile === modelData.id ? "\udb80\udd2c" : ""
+                  editable: true
+                  enabled: !vpn.busy
+                  onEntered: root.setCursorFromHover("profiles", index)
+                  onClicked: { vpn.connectProfile(modelData.id); root.showConnection() }
+                  onEditClicked: root.openEditor(modelData)
+                }
+              }
+
+              ActionRow {
+                width: profileColumn.width
+                hasCursor: root.cursorActive && root.focusSection === "profiles" && root.profileIndex === vpn.profiles.length
+                icon: "\udb81\udc15"
+                title: "New profile"
+                subtitle: vpn.profiles.length === 0 ? "Name a place, pick a colour, get there in one click" : ""
+                onEntered: root.setCursorFromHover("profiles", vpn.profiles.length)
+                onClicked: root.openEditor(null)
+              }
+            }
+
+            BorderSurface {
+              visible: root.draft !== null
+              width: parent.width
+              implicitHeight: editorColumn.implicitHeight + Style.space(20)
+              radius: Style.cornerRadius
+              color: Style.controlFill(false, false, root.foreground, Color.accent)
+              borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+
+              Column {
+                id: editorColumn
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Style.space(10)
+                anchors.rightMargin: Style.space(10)
+                spacing: Style.space(8)
+
+                TextField {
+                  id: nameField
+                  width: parent.width
+                  foreground: root.foreground
+                  placeholderText: "Name, like Home or Work"
+                  maximumLength: vpn.profileNameMax
+                  hasCursor: root.cursorActive && root.editorRow === "name"
+                  Keys.onEscapePressed: function(event) {
+                    keyCatcher.forceActiveFocus()
+                    event.accepted = true
+                  }
+                  Keys.onReturnPressed: function(event) {
+                    root.saveDraft()
+                    event.accepted = true
+                  }
+                }
+
+                // One swatch per theme colour; the chosen one grows a ring.
+                CursorSurface {
+                  id: swatchRow
+                  width: parent.width
+                  implicitHeight: Style.spacing.controlHeight
+                  hasCursor: root.cursorActive && root.editorRow === "color"
+                  foreground: root.foreground
+
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onEntered: root.setCursorFromHover("editor", 1)
+                  }
+
+                  RowLayout {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: Style.spacing.controlPaddingX
+                    anchors.rightMargin: Style.spacing.controlPaddingX
+                    spacing: Style.space(8)
+
+                    Text {
+                      text: "Colour"
+                      color: root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.body
+                      Layout.fillWidth: true
+                    }
+
+                    Repeater {
+                      model: vpn.profileColors
+                      Swatch {
+                        required property var modelData
+                        colorName: modelData
+                      }
+                    }
+                  }
+                }
+
+                SearchableDropdown {
+                  id: whereRow
+                  width: parent.width
+                  label: "Where"
+                  value: root.draft !== null ? root.draft.where : ""
+                  options: root.whereOptions
+                  placeholderText: "Search countries..."
+                  emptyText: "No countries match"
+                  hasCursor: root.cursorActive && root.editorRow === "where"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  onHovered: function(on) { if (on) root.setCursorFromHover("editor", 2) }
+                  onChanged: function(v) { root.setDraft("where", v) }
+                }
+
+                // A named server takes precedence over every flag in the CLI,
+                // so the feature is off the table for a server profile.
+                Dropdown {
+                  id: featureRow
+                  width: parent.width
+                  label: "Feature"
+                  value: root.draft !== null ? root.draft.feature : ""
+                  options: root.featureOptions
+                  enabled: root.draft !== null && root.draft.where.indexOf("server:") !== 0 && root.draft.where !== "random"
+                  opacity: enabled ? 1.0 : 0.5
+                  hasCursor: root.cursorActive && root.editorRow === "feature"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                  onHovered: function(on) { if (on) root.setCursorFromHover("editor", 3) }
+                  onChanged: function(v) { root.setDraft("feature", v) }
+                }
+
+                // Both dropdowns write their own `value` when a row is picked,
+                // which destroys a plain binding; these put the draft back in
+                // charge, so reopening the editor shows the profile's real
+                // settings and not the last thing clicked.
+                Binding { target: whereRow; property: "value"; value: root.draft !== null ? root.draft.where : "" }
+                Binding { target: featureRow; property: "value"; value: root.draft !== null ? root.draft.feature : "" }
+
+                Row {
+                  spacing: Style.space(8)
+
+                  Button {
+                    text: "Save"
+                    bordered: true
+                    foreground: root.foreground
+                    hasCursor: root.cursorActive && root.editorRow === "save"
+                    onHovered: function(on) { if (on) root.setCursorFromHover("editor", 4) }
+                    onClicked: root.saveDraft()
+                  }
+
+                  Button {
+                    text: "Cancel"
+                    foreground: root.dim
+                    hasCursor: root.cursorActive && root.editorRow === "cancel"
+                    onHovered: function(on) { if (on) root.setCursorFromHover("editor", 5) }
+                    onClicked: root.closeEditor(root.draft !== null ? root.draft.id : "")
+                  }
+
+                  Button {
+                    visible: root.draft !== null && !root.draft.isNew
+                    text: "Delete"
+                    foreground: root.urgent
+                    hasCursor: root.cursorActive && root.editorRow === "delete"
+                    onHovered: function(on) { if (on) root.setCursorFromHover("editor", 6) }
+                    onClicked: root.deleteDraft()
+                  }
+                }
+              }
+            }
+          }
+
           // ── Recent ──────────────────────────────────────────────────────
           Column {
             visible: vpn.signedIn && root.tab === "connections" && vpn.recents.length > 0
@@ -1377,11 +1777,15 @@ Panel {
   component ActionRow: CursorSurface {
     id: actionRow
     property string icon: ""
+    property color iconColor: root.foreground
     property string title: ""
     property string subtitle: ""
     property string trailing: ""
+    // A pencil on the right, and a right-click anywhere, open the editor.
+    property bool editable: false
     signal entered()
     signal clicked()
+    signal editClicked()
 
     foreground: root.foreground
     implicitHeight: actionContent.implicitHeight + Style.spacing.rowPaddingX
@@ -1392,8 +1796,13 @@ Panel {
       hoverEnabled: true
       cursorShape: actionRow.enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
       enabled: actionRow.enabled
+      acceptedButtons: actionRow.editable ? (Qt.LeftButton | Qt.RightButton) : Qt.LeftButton
       onEntered: actionRow.entered()
-      onClicked: { root.clearHighlight(); actionRow.clicked() }
+      onClicked: function(mouse) {
+        root.clearHighlight()
+        if (actionRow.editable && mouse.button === Qt.RightButton) actionRow.editClicked()
+        else actionRow.clicked()
+      }
     }
 
     RowLayout {
@@ -1407,7 +1816,7 @@ Panel {
       Text {
         visible: actionRow.icon !== ""
         text: actionRow.icon
-        color: root.foreground
+        color: actionRow.iconColor
         font.family: root.fontFamily
         font.pixelSize: Style.font.heading
         Layout.alignment: Qt.AlignVCenter
@@ -1449,6 +1858,53 @@ Panel {
         font.pixelSize: Style.font.caption
         Layout.alignment: Qt.AlignVCenter
       }
+
+      Text {
+        visible: actionRow.editable
+        text: "\udb80\udfeb"
+        color: editHover.containsMouse ? root.foreground : root.dim
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        Layout.alignment: Qt.AlignVCenter
+        leftPadding: Style.space(4)
+
+        MouseArea {
+          id: editHover
+          anchors.fill: parent
+          hoverEnabled: true
+          cursorShape: Qt.PointingHandCursor
+          onClicked: { root.clearHighlight(); actionRow.editClicked() }
+        }
+      }
+    }
+  }
+
+  // One theme colour as a dot; the chosen one is ringed in the foreground.
+  component Swatch: Item {
+    id: swatch
+    property string colorName: ""
+    readonly property bool selected: root.draft !== null && root.draft.color === colorName
+    implicitWidth: Style.space(22)
+    implicitHeight: Style.space(22)
+    Layout.alignment: Qt.AlignVCenter
+
+    Rectangle {
+      anchors.centerIn: parent
+      width: swatch.selected ? Style.space(20) : Style.space(14)
+      height: width
+      radius: width / 2
+      color: root.themeColor(swatch.colorName)
+      border.width: swatch.selected ? 2 : 0
+      border.color: root.foreground
+      Behavior on width { NumberAnimation { duration: 120 } }
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      hoverEnabled: true
+      cursorShape: Qt.PointingHandCursor
+      onEntered: root.setCursorFromHover("editor", 1)
+      onClicked: root.setDraft("color", swatch.colorName)
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ the icon it uses in notifications); delete it if you like.
 ### The bar icon
 
 The Proton mark sits in your bar in the theme's foreground colour. Solid means
-protected; dimmed means not. Connected through a [profile](#connections--profiles),
-it takes that profile's colour instead.
+protected; dimmed means not.
 
 | Action | What it does |
 | --- | --- |
@@ -222,8 +221,8 @@ The Protection tab has enough rules behind it to deserve its own chapter:
 ### Connections → Profiles
 
 A profile is a place you've named, in a colour of your theme. "Home" in green,
-"Work" in blue, "Torrents" in magenta: one click each, and the panel and bar
-icon light up in that colour while you're on it, so a glance says which one.
+"Work" in blue, "Torrents" in magenta: one click each. The row's dot wears the
+colour and the header leads with the name while you're on it.
 
 Click **New profile** and the editor opens in place of the list:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ terminal. Click the Proton mark and you're protected.
 - [What you need](#what-you-need)
 - [Install](#install), [Update](#update), [Remove](#remove)
 - [How to use it](#how-to-use-it): the bar icon, the map, quick connect,
-  countries and cities, traffic, [keyboard](#keyboard)
+  [profiles](#connections--profiles), countries and cities, traffic,
+  [keyboard](#keyboard)
 - [How the protections work](#how-the-protections-work): Kill Switch,
   NetShield, Always On, [port forwarding](#port-forwarding), split tunneling,
   and [why the Kill Switch and split tunneling can't both be on](#why-the-kill-switch-and-split-tunneling-cant-both-be-on)
@@ -132,15 +133,16 @@ protonvpn signout
 ```
 
 The widget also keeps a small folder of its own at
-`~/.local/state/omarchy-protonvpn/` (your recent locations and the icon it
-uses in notifications); delete it if you like.
+`~/.local/state/omarchy-protonvpn/` (your profiles, your recent locations and
+the icon it uses in notifications); delete it if you like.
 
 ## How to use it
 
 ### The bar icon
 
 The Proton mark sits in your bar in the theme's foreground colour. Solid means
-protected; dimmed means not.
+protected; dimmed means not. Connected through a [profile](#connections--profiles),
+it takes that profile's colour instead.
 
 | Action | What it does |
 | --- | --- |
@@ -208,14 +210,50 @@ you exit from.
 ### Two tabs: Connections and Protection
 
 Under Quick Connect sit two tabs, in the same pill style as Omarchy's network
-panel. **Connections** holds everywhere you can go: recent places, and the
-country and city lists. **Protection** holds everything about *how* you're
+panel. **Connections** holds everywhere you can go: your profiles, recent
+places, and the country and city lists. **Protection** holds everything about *how* you're
 protected: the Kill Switch, NetShield, Always On, port forwarding, split
 tunneling, and your
 account. The tab you pick stays until you close the panel.
 
 The Protection tab has enough rules behind it to deserve its own chapter:
 [How the protections work](#how-the-protections-work).
+
+### Connections → Profiles
+
+A profile is a place you've named, in a colour of your theme. "Home" in green,
+"Work" in blue, "Torrents" in magenta: one click each, and the panel and bar
+icon light up in that colour while you're on it, so a glance says which one.
+
+Click **New profile** and the editor opens in place of the list:
+
+| Field | What it takes |
+| --- | --- |
+| Name | Whatever you'd call it, up to 32 characters |
+| Colour | One of the theme's seven names: accent, red, yellow, green, cyan, blue, magenta |
+| Where | Fastest, Random, any country, or the exact server you're on right now |
+| Feature | None, P2P, Secure Core or Tor |
+
+A new profile starts where you are: the top of Recent, which is the server or
+country you last asked for. If that was a specific server, it's offered as an
+option under **Where**; pick a country instead and you get the fastest server
+there each time. The feature is added on top of a country ("fastest P2P in
+Switzerland"), and greyed out for a named server, because the CLI ignores every
+flag once a server is named.
+
+The colour is stored by name, not by value. Switch from Tokyo Night to Jade and
+every profile is repainted in Jade's idea of blue or magenta on its own. That's
+the whole reason the choices are the theme's names and not a colour picker.
+
+To change or remove one, click the pencil on its row, right-click the row, or
+press `e` with the row selected. The same editor comes back with a **Delete**
+button. Nothing is written until you press **Save**; `Esc` drops the draft.
+
+Connecting through a profile records the place to Recent the same way the row
+it stands for would, and Always On reconnects to that place, not to the
+profile. Profiles hold *where* to connect and which feature to ask for; the
+Kill Switch, NetShield and the other switches on the Protection tab are yours
+for every connection, so a profile doesn't change them.
 
 ### Connections → Recent
 
@@ -306,10 +344,16 @@ Everything in the panel is reachable without a mouse.
 | `Enter` | Activate: connect, flip a switch, open a picker |
 | `Esc` | Back out one level, then close the panel |
 | `/` | Jump to the country filter |
+| `e` | Edit the selected profile |
 
-There are no single-letter shortcuts on purpose: the panel takes keyboard
-focus when it opens, and a stray keystroke should never change your
-connection.
+There are no single-letter shortcuts that touch the tunnel, on purpose: the
+panel takes keyboard focus when it opens, and a stray keystroke should never
+change your connection. `e` only opens the editor for the profile under the
+selection, which changes nothing until you save.
+
+Inside the profile editor, `↑` `↓` move between the fields, `←` `→` walk the
+colour swatches, `Enter` puts the cursor in the name or opens a picker, and
+`Enter` in the name field saves.
 
 `Enter` on **Mode** or **Apps** opens that picker, which then owns the
 keyboard: inside the Apps list, typing filters it, arrows move, `Enter` ticks,
@@ -599,8 +643,8 @@ Omarchy plugin. It:
   connected-city lookup all come from it), reads the tunnel's byte counters
   under `/sys/class/net/` once a second while the panel is open, and writes
   two files of its own under `~/.local/state/omarchy-protonvpn/`
-  (`state.json`: recent location labels, whether you dismissed the Kill
-  Switch prompt, and whether Always On is on; `notification-icon.svg`: the
+  (`state.json`: your profiles, recent location labels, whether you dismissed
+  the Kill Switch prompt, and whether Always On is on; `notification-icon.svg`: the
   Proton mark in your theme's colour, for the notification)
 - writes one file that isn't its own, and only if you turn split tunneling on:
   `~/.config/Proton/VPN/settings.json`, Proton's own settings. Rules below.

--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ independently of the tunnel.
 Blocks malware, ads, and trackers at the DNS level, on Proton's side. Three
 levels: off, malware only, or malware plus ads and trackers. The switch asks
 for the full level; on a free plan Proton only allows malware blocking, and
-the widget steps down to that automatically instead of failing. The row is
-tagged Plus, and once stepped down it says that ads and trackers need Plus,
-so a free account knows what it got.
+the widget steps down to that automatically instead of failing. The row wears
+the same PLUS tag as the Quick Connect rows, and once stepped down it says
+that ads and trackers need Plus, so a free account knows what it got.
 
 ### Always On
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,9 @@ independently of the tunnel.
 Blocks malware, ads, and trackers at the DNS level, on Proton's side. Three
 levels: off, malware only, or malware plus ads and trackers. The switch asks
 for the full level; on a free plan Proton only allows malware blocking, and
-the widget steps down to that automatically instead of failing.
+the widget steps down to that automatically instead of failing. The row is
+tagged Plus, and once stepped down it says that ads and trackers need Plus,
+so a free account knows what it got.
 
 ### Always On
 

--- a/Service.qml
+++ b/Service.qml
@@ -124,7 +124,7 @@ Item {
     portProcess.running = true
   }
 
-  onConnectedChanged: if (!connected) forwardedPort = ""
+  onConnectedChanged: if (!connected) { forwardedPort = ""; activeProfile = "" }
 
   // Copy is the only thing the widget ever does with the port.
   function copyForwardedPort() {
@@ -137,6 +137,25 @@ Item {
   property var recents: []
   property bool nudgeDismissed: false
   property bool stateLoaded: false
+
+  // ── Profiles ────────────────────────────────────────────────────────────
+  // A named place to connect to, in a colour of the theme: {id, name, color,
+  // args, title, subtitle}. `color` is the name of a theme colour ("blue",
+  // "magenta"…), never a hex value, so a profile keeps its role across theme
+  // switches: blue in Tokyo Night is a different blue in Nord, and that is
+  // the point. `args` is the same argv a recent carries, plus the feature
+  // flags, and `title`/`subtitle` describe the place the way Recent would.
+  property var profiles: []
+  readonly property var profileColors: ["accent", "red", "yellow", "green", "cyan", "blue", "magenta"]
+  readonly property int profileNameMax: 32
+  // The profile the live connection was started from, or "". Not persisted:
+  // after a restart the tunnel is the tunnel, and no profile claims it.
+  property string activeProfile: ""
+  readonly property var activeProfileEntry: {
+    if (activeProfile === "") return null
+    for (var i = 0; i < profiles.length; i++) if (profiles[i].id === activeProfile) return profiles[i]
+    return null
+  }
 
   // ── Always On ───────────────────────────────────────────────────────────
   // One invariant, not a set of triggers: if the switch is on and the tunnel
@@ -641,6 +660,8 @@ Item {
 
   function connectTo(args, label, target, auto) {
     if (!installed || !signedIn || busy) return
+    // Any connect that isn't a profile click ends the profile's claim.
+    activeProfile = ""
     p2pRequested = args.indexOf("--p2p") !== -1
     _autoAttempt = auto === true
     _desired = 1
@@ -684,6 +705,83 @@ Item {
     var r = recents[index]
     if (!r || !Array.isArray(r.args)) return
     connectTo(r.args, "Connecting to " + r.title + "…", r)
+  }
+
+  // A profile connects like the row it was made from: a country or server
+  // profile records that place to Recent, a feature-only one (P2P, Tor,
+  // Fastest) records wherever the CLI landed, exactly as the quick rows do.
+  function connectProfile(id) {
+    var p = null
+    for (var i = 0; i < profiles.length; i++) if (profiles[i].id === id) p = profiles[i]
+    if (!p || busy) return
+    var target = profileNamesPlace(p.args)
+      ? { key: "args:" + p.args.join(" "), title: p.title, subtitle: p.subtitle, args: p.args }
+      : null
+    connectTo(p.args, "Connecting to " + p.name + "…", target)
+    if (connectProcess.running) activeProfile = p.id
+  }
+
+  function profileNamesPlace(args) {
+    for (var i = 0; i < args.length; i++) if (args[i].charAt(0) !== "-") return true
+    return false
+  }
+
+  // Build the args and the place description from the editor's three
+  // choices. `where` is "" (fastest), "random", "country:CC" or
+  // "server:NAME"; `feature` is "", "p2p", "securecore" or "tor". A named
+  // server takes precedence over every flag in the CLI, so a feature on a
+  // server profile is dropped rather than stored as a lie.
+  function buildProfile(id, name, color, where, feature, placeTitle, placeSubtitle) {
+    var args = []
+    var title = "Fastest"
+    var subtitle = "Best server for your location"
+    var w = String(where || "")
+    if (w === "random") { args = ["--random"]; title = "Random"; subtitle = "Any available server" }
+    else if (w.indexOf("country:") === 0) {
+      var c = w.slice(8).toUpperCase()
+      if (!/^[A-Z]{2}$/.test(c)) return null
+      args = ["--country", c]
+      title = countryName(c)
+      subtitle = "Fastest server"
+    } else if (w.indexOf("server:") === 0) {
+      var n = w.slice(7)
+      if (!connectArg.test(n) || n.charAt(0) === "-") return null
+      args = [n]
+      title = placeTitle || n
+      subtitle = placeSubtitle || ""
+      feature = ""
+    }
+    var flag = { p2p: "--p2p", securecore: "--securecore", tor: "--tor" }[feature]
+    if (flag && w !== "random") {
+      args.push(flag)
+      var label = { p2p: "P2P", securecore: "Secure Core", tor: "Tor" }[feature]
+      if (w === "") { title = "Fastest " + label; subtitle = label === "P2P" ? "Optimized for file sharing" : "Via " + label }
+      else subtitle = subtitle === "" ? label : subtitle + " · " + label
+    }
+    return cleanProfile({ id: id, name: name, color: color, args: args, title: title, subtitle: subtitle })
+  }
+
+  // Upsert by id; a new profile gets a fresh id and goes last.
+  function saveProfile(p) {
+    var clean = cleanProfile(p)
+    if (!clean) return false
+    var next = profiles.slice()
+    var found = false
+    for (var i = 0; i < next.length; i++) if (next[i].id === clean.id) { next[i] = clean; found = true }
+    if (!found) next.push(clean)
+    profiles = next
+    saveState()
+    return true
+  }
+
+  function deleteProfile(id) {
+    profiles = profiles.filter(function(p) { return p.id !== id })
+    if (activeProfile === id) activeProfile = ""
+    saveState()
+  }
+
+  function newProfileId() {
+    return "p" + Date.now().toString(36) + Math.floor(Math.random() * 1e6).toString(36)
   }
 
   function loadServers(code, name) {
@@ -918,14 +1016,28 @@ Item {
     return { key: r.key, title: String(r.title || ""), subtitle: String(r.subtitle || ""), args: args }
   }
 
+  // Same rules as a recent for the argv, plus a name that fits on a row and
+  // a colour that is one of the theme's names. Anything else is dropped.
+  function cleanProfile(p) {
+    if (!p || typeof p !== "object" || typeof p.id !== "string" || !/^[A-Za-z0-9]{1,24}$/.test(p.id)) return null
+    var place = cleanRecent({ key: p.id, title: p.title, subtitle: p.subtitle, args: p.args })
+    if (!place) return null
+    var name = String(p.name || "").replace(/\s+/g, " ").trim().slice(0, profileNameMax)
+    if (name === "") return null
+    var color = profileColors.indexOf(p.color) !== -1 ? p.color : "accent"
+    return { id: p.id, name: name, color: color, args: place.args, title: place.title, subtitle: place.subtitle }
+  }
+
   function applyState(text) {
     try {
       var s = JSON.parse(String(text || "{}"))
       recents = Array.isArray(s.recents) ? s.recents.slice(0, 3).map(cleanRecent).filter(Boolean) : []
+      profiles = Array.isArray(s.profiles) ? s.profiles.slice(0, 24).map(cleanProfile).filter(Boolean) : []
       nudgeDismissed = s.killSwitchNudgeDismissed === true
       autoConnect = s.autoConnect === true
     } catch (e) {
       recents = []
+      profiles = []
       nudgeDismissed = false
       autoConnect = false
     }
@@ -935,6 +1047,7 @@ Item {
   function saveState() {
     stateFile.setText(JSON.stringify({
       recents: recents,
+      profiles: profiles,
       killSwitchNudgeDismissed: nudgeDismissed,
       autoConnect: autoConnect
     }))
@@ -1429,6 +1542,7 @@ Item {
       else if (wasAuto) root._autoPinFailed = true
       if (exitCode !== 0) {
         root._desired = -1
+        root.activeProfile = ""
         var text = err || out || "Connect failed"
         root.lastError = Model.isPlanError(text) ? "Requires a Proton VPN Plus plan" : Model.elide(text)
         root.actionStatus = root.lastError

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.grichard99.omaproton-vpn",
   "name": "OmaProton VPN",
-  "version": "1.4.2",
+  "version": "1.4.4",
   "author": "grichard99",
   "license": "MIT",
   "description": "Proton VPN, built for Omarchy. No terminal: one click to connect, a world map of cities, Kill Switch, in a widget that wears every Omarchy theme.",

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   },
   "barWidget": {
     "displayName": "OmaProton VPN",
-    "description": "Toggle Proton VPN, quick-connect by feature, pick a country or city, and manage Kill Switch, NetShield, Always On and split tunneling.",
+    "description": "Toggle Proton VPN, quick-connect by feature, save named profiles in your theme's colours, pick a country or city, and manage Kill Switch, NetShield, Always On and split tunneling.",
     "category": "Network",
     "allowMultiple": false,
     "defaultSection": "right",


### PR DESCRIPTION
Profiles: name the places you connect to, give each one a colour from your theme, and get there in one click. Plus a small fix on the NetShield row.

## Profiles

Most people connect to the same two or three places forever. Recent already put those one click away, but it forgets a place the moment you try something else, and it never knows what you call it. Profiles fix that.

A profile is a name, a colour, a destination and an optional feature. "Home" in green. "Work" in blue. "Torrents" in magenta, set to the fastest P2P server in Switzerland. They sit above Recent on the Connections tab, and while you're connected through one, its name leads the header: **Work · NL#12**.

Click **New profile** and an editor opens in place of the list:

- **Name**, up to 32 characters.
- **Colour**, one of your theme's own: accent, red, yellow, green, cyan, blue or magenta.
- **Where**: Fastest, Random, any country, or the exact server you're on right now.
- **Feature**: none, P2P, Secure Core or Tor. It's greyed out for a named server, because the CLI ignores every flag once a server is named.

A new profile starts where you are, so the natural flow is connect somewhere, like it, name it. Nothing is written until you press **Save**, and `Esc` throws the draft away.

To change one, click the pencil on its row, right-click the row, or press `e` with the row selected. The same editor comes back with a **Delete** button.

### About the colours

The colour is saved by name, never by value. Switch from Tokyo Night to Osaka Jade and every profile is repainted in Jade's blue and Jade's magenta on its own, because the widget reads the seven names from whatever theme is current. That's why the choices are the theme's names and not a colour picker: a picked hex would survive a theme switch and clash with everything around it. All of Omarchy's shipped themes define those seven.

### What a profile doesn't do

It holds where to go and which feature to ask for. The Kill Switch, NetShield and the other switches on the Protection tab are yours for every connection, so a profile leaves them alone. Connecting through a profile records the place to Recent the same way the row it stands for would, and Always On keeps reconnecting to that place.

Asked for by @r8tten in #41. Thanks for the suggestion.

## NetShield says Plus

The NetShield row now wears the same **PLUS** tag the P2P, Secure Core and Tor rows have, so it's clear up front that the full level needs a paid plan. On a free plan the widget already steps NetShield down to malware-only instead of failing; the row now says so, with "Ads and trackers need Plus" under the label, instead of coming on and leaving you to wonder why the ads stayed.

Asked for by @levyvix in #34.

## README

A Profiles chapter under Connections, the keyboard table gains `e` and the editor's keys, and the state file notes mention profiles. Your profiles live with your recents in `~/.local/state/omarchy-protonvpn/state.json`, readable by you alone.

## Upgrade

```
omarchy plugin update io.github.grichard99.omaproton-vpn
```
