### PR TITLE
OmaProton VPN 1.4.5

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -84,6 +84,14 @@ function parseStatus(raw) {
   }
 }
 
+// True when `raw` carries a whole answer from `protonvpn status`: a Status
+// line whose value is one of the words the CLI prints. Tells a run that
+// answered and then died on its way out from one that never answered.
+function statusComplete(raw) {
+  var v = parseKeyValues(raw).map["status"] || ""
+  return /^(connected|connecting|disconnected)$/i.test(v)
+}
+
 // "CH-US#3", "IS-JP#1", "SE-FR#2": only CH, IS and SE are entry countries.
 function isSecureCore(name) {
   return /^(CH|IS|SE)-[A-Z]{2}/i.test(String(name || "").trim())

--- a/Panel.qml
+++ b/Panel.qml
@@ -1304,6 +1304,7 @@ Panel {
               }
 
               Toggle {
+                id: portForwardRow
                 width: parent.width
                 label: "Port forwarding"
                 description: {
@@ -1322,6 +1323,10 @@ Panel {
                 fontFamily: root.fontFamily
                 onHovered: function(on) { if (on) root.setCursorFromHover("protection", 3) }
                 onClicked: { root.clearHighlight(); root.requestPortForwarding() }
+
+                // Needs a paid plan, like NetShield: the same tag, on the
+                // label's line, so a free account isn't told by a refusal.
+                LabelTag { row: portForwardRow; text: "PLUS" }
               }
 
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -325,7 +325,11 @@ Panel {
       else list.push({ name: "profiles", count: vpn.profiles.length + 1 })
       if (vpn.recents.length > 0) list.push({ name: "recents", count: vpn.recents.length })
       if (drilled) list.push({ name: "servers", count: serverRowCount })
-      else if (filteredCountries.length > 0) list.push({ name: "countries", count: filteredCountries.length })
+      else {
+        // The COUNTRIES header is a row of its own: it folds the list.
+        list.push({ name: "countriesHeader", count: 1 })
+        if (vpn.countriesExpanded && filteredCountries.length > 0) list.push({ name: "countries", count: filteredCountries.length })
+      }
     }
     return list
   }
@@ -361,9 +365,11 @@ Panel {
     var pos = -1
     for (var i = 0; i < list.length; i++) if (list[i].name === focusSection) pos = i
     if (pos === -1) {
-      // Countries and servers stand in for each other across a drill.
+      // Countries and servers stand in for each other across a drill, and
+      // a folded list hands its cursor to the header that folded it.
       if (focusSection === "countries" && drilled) focusSection = "servers"
-      else if (focusSection === "servers" && !drilled) focusSection = "countries"
+      else if (focusSection === "servers" && !drilled) focusSection = vpn.countriesExpanded ? "countries" : "countriesHeader"
+      else if (focusSection === "countries") focusSection = "countriesHeader"
       else focusSection = list[0].name
       for (i = 0; i < list.length; i++) if (list[i].name === focusSection) pos = i
       if (pos === -1) { focusSection = list[0].name; pos = 0 }
@@ -441,6 +447,9 @@ Panel {
       if (focusSection === "editor") { if (editorRow === "color") cycleColor(dx); return }
       if (dx > 0 && focusSection === "countries") drillInto(filteredCountries[countryIndex])
       else if (dx < 0 && focusSection === "servers") drillOut()
+      // On the header they unfold and fold the list, the way they open and
+      // close a country.
+      else if (focusSection === "countriesHeader") setCountriesExpanded(dx > 0)
       return
     }
     if (dy === 0) return
@@ -493,8 +502,18 @@ Panel {
     // Enter on a country opens its servers rather than connecting blind,
     // the first row inside is still "Fastest in <country>", so the old
     // one-keystroke behaviour is only ever one row away.
+    else if (focusSection === "countriesHeader") setCountriesExpanded(!vpn.countriesExpanded)
     else if (focusSection === "countries") drillInto(filteredCountries[countryIndex])
     else if (focusSection === "servers") activateServerRow(serverIndex)
+  }
+
+  // The country list stays folded until asked for, and stays how it was
+  // left, across opens and shell restarts. Unfolding puts its header at the
+  // top of the view, the way a drill does, so the rows fill the panel.
+  function setCountriesExpanded(on) {
+    if (vpn.countriesExpanded === on) return
+    vpn.setCountriesExpanded(on)
+    if (on) anchorCountrySection()
   }
 
   function activateServerRow(index) {
@@ -604,6 +623,7 @@ Panel {
     else if (focusSection === "profiles") column = profileColumn
     else if (focusSection === "editor") column = editorColumn
     else if (focusSection === "recents") column = recentColumn
+    else if (focusSection === "countriesHeader") column = countrySection
     else if (focusSection === "countries") column = countryColumn
     else if (focusSection === "servers") column = serverColumn
     var i = sectionIndex(focusSection)
@@ -708,6 +728,7 @@ Panel {
         portForwarding: vpn.config["port-forwarding"] || "",
         forwardedPort: vpn.forwardedPort,
         countries: vpn.countries.length,
+        countriesExpanded: vpn.countriesExpanded,
         recents: vpn.recents.length,
         cities: vpn.cities.length,
         traffic: { device: vpn.linkDevice, samples: vpn.rxHistory.length, rx: vpn.rxRate, tx: vpn.txRate },
@@ -804,7 +825,8 @@ Panel {
       // keyboard focus when it opens, and a stray keystroke must never change
       // it. "e" only opens the editor for the profile under the cursor.
       onTextKey: function(t) {
-        if (t === "/") filterField.forceActiveFocus()
+        // The filter lives inside the list, so "/" unfolds it first.
+        if (t === "/") { root.setCountriesExpanded(true); filterField.forceActiveFocus() }
         else if (t === "e" && root.cursorActive && root.focusSection === "profiles"
                  && root.profileIndex < vpn.profiles.length) root.openEditor(vpn.profiles[root.profileIndex])
       }
@@ -1675,11 +1697,60 @@ Panel {
             width: parent.width
             spacing: Style.space(10)
 
-            PanelSectionHeader {
-              text: root.drilled ? String(vpn.serversCountryName).toUpperCase() : "COUNTRIES"
-              textFormat: Text.PlainText
+            // The header is a row: it folds the list away and unfolds it,
+            // and carries the count while the rows are hidden. It hangs out
+            // past the column by a row's inset so its title stays in line
+            // with the other section headers. Inside a drill it is only the
+            // country's name, with nothing to click.
+            CursorSurface {
+              id: countriesHeader
+              x: -Style.space(10)
+              width: parent.width + Style.space(20)
+              hasCursor: !root.drilled && root.cursorActive && root.focusSection === "countriesHeader"
               foreground: root.foreground
-              fontFamily: root.fontFamily
+              implicitHeight: headerLabel.implicitHeight + Style.space(10)
+
+              MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                enabled: !root.drilled
+                cursorShape: Qt.PointingHandCursor
+                onEntered: root.setCursorFromHover("countriesHeader", 0)
+                onClicked: { root.clearHighlight(); root.setCountriesExpanded(!vpn.countriesExpanded) }
+              }
+
+              PanelSectionHeader {
+                id: headerLabel
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(10)
+                anchors.verticalCenter: parent.verticalCenter
+                text: root.drilled ? String(vpn.serversCountryName).toUpperCase() : "COUNTRIES"
+                textFormat: Text.PlainText
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+              }
+
+              Text {
+                anchors.left: headerLabel.right
+                anchors.leftMargin: Style.space(8)
+                anchors.verticalCenter: headerLabel.verticalCenter
+                visible: !root.drilled && vpn.countriesLoaded
+                text: String(vpn.countries.length)
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+              }
+
+              Text {
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(10)
+                anchors.verticalCenter: headerLabel.verticalCenter
+                visible: !root.drilled
+                text: vpn.countriesExpanded ? "\udb80\udd40" : "\udb80\udd42"
+                color: root.dim
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.body
+              }
             }
 
             BackRow {
@@ -1720,7 +1791,7 @@ Panel {
 
             TextField {
               id: filterField
-              visible: !root.drilled
+              visible: !root.drilled && vpn.countriesExpanded
               width: parent.width
               foreground: root.foreground
               placeholderText: vpn.countriesLoaded ? "Filter countries  (press /)" : "Loading countries…"
@@ -1747,7 +1818,7 @@ Panel {
             }
 
             Text {
-              visible: !root.drilled && vpn.countriesLoaded && root.filteredCountries.length === 0
+              visible: !root.drilled && vpn.countriesExpanded && vpn.countriesLoaded && root.filteredCountries.length === 0
               width: parent.width
               text: "No countries match."
               color: root.dim
@@ -1758,7 +1829,7 @@ Panel {
 
             Column {
               id: countryColumn
-              visible: !root.drilled
+              visible: !root.drilled && vpn.countriesExpanded
               width: parent.width
               spacing: Style.space(6)
 

--- a/README.md
+++ b/README.md
@@ -267,9 +267,16 @@ That top entry is also what Always On reconnects to.
 
 ### Connections → Countries and cities
 
-Below that is the full country list. **Clicking a country doesn't connect**,
-it drills into that country's cities, so you can see where you'll land before
-you commit.
+Below that is the full country list, folded away behind its **COUNTRIES**
+header until you want it. Most opens are a glance at the map, Fastest, a
+profile or a recent, and a hundred and fifty rows under those only push the
+panel to the edge of the screen. The header shows the count; click it, or
+press `Enter` or `→` on it, and the list opens with the filter box at its
+top. It stays open or folded the way you left it, across opens and shell
+restarts, and `/` opens it for you on the way to the filter.
+
+**Clicking a country doesn't connect**, it drills into that country's cities,
+so you can see where you'll land before you commit.
 
 <img src="docs/city-list.png" width="360" alt="Connections tab with Japan drilled open, Osaka, clicked on the map, is ringed">
 
@@ -338,11 +345,11 @@ Everything in the panel is reachable without a mouse.
 | Key | What it does |
 | --- | --- |
 | `↑` `↓` or `k` `j` | Move through every section, top to bottom |
-| `→` or `l` | Open the selected country's city list |
-| `←` or `h` | Back out to the country list |
-| `Enter` | Activate: connect, flip a switch, open a picker |
+| `→` or `l` | Open the selected country's city list, or unfold the country list from its header |
+| `←` or `h` | Back out to the country list, or fold it from its header |
+| `Enter` | Activate: connect, flip a switch, open a picker, fold or unfold the country list |
 | `Esc` | Back out one level, then close the panel |
-| `/` | Jump to the country filter |
+| `/` | Jump to the country filter, unfolding the list if it was folded |
 | `e` | Edit the selected profile |
 
 There are no single-letter shortcuts that touch the tunnel, on purpose: the

--- a/Service.qml
+++ b/Service.qml
@@ -136,6 +136,9 @@ Item {
   // kill-switch nudge was dismissed. Location labels only, nothing secret.
   property var recents: []
   property bool nudgeDismissed: false
+  // The Connections tab's country list is folded away until asked for, and
+  // stays however it was last left.
+  property bool countriesExpanded: false
   property bool stateLoaded: false
 
   // ── Profiles ────────────────────────────────────────────────────────────
@@ -1035,11 +1038,13 @@ Item {
       profiles = Array.isArray(s.profiles) ? s.profiles.slice(0, 24).map(cleanProfile).filter(Boolean) : []
       nudgeDismissed = s.killSwitchNudgeDismissed === true
       autoConnect = s.autoConnect === true
+      countriesExpanded = s.countriesExpanded === true
     } catch (e) {
       recents = []
       profiles = []
       nudgeDismissed = false
       autoConnect = false
+      countriesExpanded = false
     }
     stateLoaded = true
   }
@@ -1049,8 +1054,15 @@ Item {
       recents: recents,
       profiles: profiles,
       killSwitchNudgeDismissed: nudgeDismissed,
-      autoConnect: autoConnect
+      autoConnect: autoConnect,
+      countriesExpanded: countriesExpanded
     }))
+  }
+
+  function setCountriesExpanded(on) {
+    if (countriesExpanded === on) return
+    countriesExpanded = on
+    saveState()
   }
 
   // ── Always On ───────────────────────────────────────────────────────────

--- a/Service.qml
+++ b/Service.qml
@@ -1369,11 +1369,22 @@ Item {
     command: []
     stdout: StdioCollector { id: statusStdout; waitForEnd: true }
     stderr: StdioCollector { id: statusStderr; waitForEnd: true }
-    onExited: function(exitCode) {
+    // `protonvpn status` sometimes prints its whole answer and then dies on
+    // the way out: a worker thread in Proton's native extension is still
+    // running while the interpreter is being torn down, and the process ends
+    // on a signal after everything was written and flushed. That reaches
+    // here as a crash exit with the signal number for a code. A crash after
+    // a complete Status line is a crash of the exit path, not of the answer,
+    // so the answer is kept. A normal non-zero exit is still the CLI saying
+    // it failed, and an unfinished line, a traceback or no output at all is
+    // still an error whatever ended the process.
+    onExited: function(exitCode, exitStatus) {
       root._probeRunning = false
       Qt.callLater(root.drainProbes)
-      if (exitCode === 0) {
-        root.applyStatus(String(statusStdout.text || ""))
+      var out = String(statusStdout.text || "")
+      var crashed = exitStatus !== 0
+      if (exitCode === 0 || (crashed && Model.statusComplete(out))) {
+        root.applyStatus(out)
         root.lastError = ""
       } else {
         root.lastError = Model.elide(String(statusStderr.text || "") || "protonvpn status failed")

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.grichard99.omaproton-vpn",
   "name": "OmaProton VPN",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "author": "grichard99",
   "license": "MIT",
   "description": "Proton VPN, built for Omarchy. No terminal: one click to connect, a world map of cities, Kill Switch, in a widget that wears every Omarchy theme.",


### PR DESCRIPTION
Three small things, one release.

## What it does

**Keeps a status answer that arrives ahead of a crash (#49).** `protonvpn status` sometimes prints its whole answer and then dies on the way out: a worker thread in Proton's native extension is still running while the interpreter is torn down, and the process ends on SIGSEGV after everything was written and flushed. The panel only trusted exit code 0, so it threw the good answer away and showed "protonvpn status failed" over a tunnel that was fine.

A crash exit that follows a complete Status line is now kept. Quickshell reports a signal death as exitStatus 1 with the signal number for a code, and the CLI's only two output shapes both start with "Status:", so the answer counts as complete when that value is one of the words the CLI prints (Connected, Disconnected, Connecting). A normal non-zero exit is still the CLI saying it failed. An unfinished line, a traceback, or no output at all is still an error, whatever ended the process. Reported by teslacybrtrk.

**Tags Port forwarding as a Plus feature (#47).** The same PLUS tag NetShield and the Quick Connect rows wear, on the label's line.

**Folds the country list behind its header (#48, first half).** The list stays folded behind COUNTRIES until asked for. The header is a row of its own: it carries the count while the rows are hidden, a chevron says which way it goes, and a click, Enter, or the right and left arrows unfold and fold it, the way they open and close a country. "/" unfolds the list on its way to the filter. Unfolding puts the header at the top of the view, as a drill does. The state lives in state.json, so it stays how it was left across opens and shell restarts. A drill is untouched: inside a country the header is the country's name with nothing to click. Suggested by teslacybrtrk.

The header hangs out past the column by a row's inset so its title stays in line with the other section headers while its cursor ring reads like every other row's.

## How it was reviewed

The two reports came with code. Neither snippet was used. The status bug was traced from Proton's own CLI source (the `status` command prints its lines with `click.echo` and returns; every failure path exits through `sys.exit(1)` without a Status line) and from Quickshell's exit signal, then reproduced against a stand-in CLI, not taken from the report. The fold was designed from the panel's existing section walk.

## What was tested

- A harness that loads the real Service with a stand-in `protonvpn` on PATH. Staging shows "protonvpn status failed" when the stand-in prints a full status and kills itself with SIGSEGV; this branch shows Connected with the server. A crash after "Status: Conn", a traceback with exit 1, empty output with a crash, and a clean "exit 1" after a full answer are all still rejected. A crash after "Status: Disconnected" reads Disconnected.
- A harness that loads the real Panel: the section walk carries the header and no country rows while folded; a cursor left on "countries" or "servers" lands on the header; left and right on the header fold and unfold; Enter toggles; the fold state lands in state.json and is read back.
- A walk of the loaded Panel's object tree finds the PLUS tag on the Port forwarding row at the same height as NetShield's.
- The real `protonvpn status` ran 40 times here without a crash; this machine has api-core 5.6.10 where the reporter has local-agent 1.6.3, so the crash itself was not reproduced natively.
- `omarchy plugin validate .` passes. No QML warnings in either harness or in the live shell's reload log.

## Not in this

- The square Quick Connect button row from #48. Not doing it.
- Scrolling the country list inside a fixed-height panel. The panel already caps its height and scrolls as a whole, and folding the list is what gives the compact view.
- Anything from PR #40.

## Release

`manifest.json` is bumped to 1.4.5. README documents the folded list and the new keys.

- Closes #47
- Closes #48
- Closes #49
